### PR TITLE
Read a zoneless supplier date as a Dutch wall clock when projecting

### DIFF
--- a/src/quickwit/project.ts
+++ b/src/quickwit/project.ts
@@ -10,6 +10,7 @@ import type {
   WooziEntity,
 } from "../types.ts";
 import { currentProjectionVersion } from "../pipeline/versioning.ts";
+import { supplierDateTimeToUtc } from "../util/local_time.ts";
 
 export interface QuickwitSearchDocument {
   time: string;
@@ -64,6 +65,31 @@ function toIndexDateTime(value?: string): string | undefined {
     return undefined;
   }
 
+  // A reading without a zone is a Dutch wall clock, not UTC.
+  //
+  // This is where #203 actually lived. The suppliers' own normalisers already
+  // convert (`supplierDateTimeToUtc`), but they only run at import time, and
+  // the export log faithfully kept what they produced *before* that fix: bare
+  // readings like `2023-11-28 19:30:00`. Projection then handed those to
+  // `new Date()`, which in a UTC container reads them as 19:30 UTC and stamps
+  // `2023-11-28T19:30:00Z` — a council meeting claimed an hour or two late,
+  // and near midnight a whole day off, which moves it into the wrong
+  // `dateFrom`/`dateTo` window.
+  //
+  // Doing it here rather than only at import is what makes the backlog
+  // repairable: the raw wall clock survives in the export log, so a
+  // reindex_only re-projects it correctly without asking a supplier anything.
+  const normalized = supplierDateTimeToUtc(trimmed);
+  if (normalized) {
+    return normalized;
+  }
+
+  // Fallback for shapes supplierDateTimeToUtc does not recognise but Date
+  // does, e.g. sub-second precision. Kept because the cost of the two
+  // outcomes is not symmetric: an unparseable value makes Quickwit drop the
+  // whole entity, while a slightly wrong one costs a badly sorted row. A
+  // zoneless reading that lands here is still stamped as UTC, but every shape
+  // the suppliers are known to emit is handled above.
   const parsed = new Date(trimmed);
   if (Number.isNaN(parsed.getTime())) {
     return undefined;

--- a/tests/motions.test.ts
+++ b/tests/motions.test.ts
@@ -1,8 +1,5 @@
 import { __test__ as ibabsClientTest } from "../src/ibabs/client.ts";
-import {
-  IbabsMeetingExtractor,
-  __test__ as ibabsExtractorTest,
-} from "../src/ibabs/extractor.ts";
+import { IbabsMeetingExtractor, __test__ as ibabsExtractorTest } from "../src/ibabs/extractor.ts";
 import { normalizeIbabsMotion, normalizeIbabsMotionDocuments } from "../src/ibabs/normalize.ts";
 import {
   MeetingIndex,
@@ -30,12 +27,13 @@ function assert(condition: unknown, message: string): asserts condition {
 
 function assertEquals<T>(actual: T, expected: T, message: string): void {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    throw new Error(
+      `${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
   }
 }
 
-const fixture = (name: string) =>
-  Deno.readTextFile(new URL(`./fixtures/${name}`, import.meta.url));
+const fixture = (name: string) => Deno.readTextFile(new URL(`./fixtures/${name}`, import.meta.url));
 
 Deno.test("iBabs list parsers read registries, entries, values and votes", async () => {
   const lists = ibabsClientTest.parseListsXml(await fixture("ibabs_lists_response.xml"));
@@ -152,7 +150,9 @@ Deno.test("an iBabs motion normalizes with votes, tally and a meeting link", asy
   );
 
   const meetings = new MeetingIndex();
-  meetings.add(meetingFixture("meeting:ibabs:gemeente:utrecht:m1", "Gemeenteraad", "2026-01-29T00:00:00Z"));
+  meetings.add(
+    meetingFixture("meeting:ibabs:gemeente:utrecht:m1", "Gemeenteraad", "2026-01-29T00:00:00Z"),
+  );
 
   const motion = normalizeIbabsMotion(source, list, entries[0], detail, votes, meetings);
 
@@ -178,7 +178,11 @@ Deno.test("an iBabs motion normalizes with votes, tally and a meeting link", asy
   assert(firstVote.group?.startsWith("party:ibabs:"), "group resolves to a canonical party id");
 
   assertEquals(motion.meeting, "meeting:ibabs:gemeente:utrecht:m1", "linked meeting");
-  assertEquals(motion.agenda_item, "meeting:ibabs:gemeente:utrecht:m1:item-23", "linked agenda item");
+  assertEquals(
+    motion.agenda_item,
+    "meeting:ibabs:gemeente:utrecht:m1:item-23",
+    "linked agenda item",
+  );
   assertEquals(motion.agenda_item_hint, undefined, "hint dropped once fully resolved");
 
   const documents = normalizeIbabsMotionDocuments(source, motion, detail);
@@ -243,7 +247,9 @@ Deno.test("a Notubiz motion normalizes with an exact agenda-item link", async ()
     name: "Gemeenteraad",
     classification: ["Agenda"],
     start_date: "2026-02-19T19:30:00Z",
-    agenda: [{ id: canonicalAgendaItemId(source, 9977098), title: "Geotechnisch onderzoek", order: 15 }],
+    agenda: [
+      { id: canonicalAgendaItemId(source, 9977098), title: "Geotechnisch onderzoek", order: 15 },
+    ],
     source_info: { supplier: "notubiz", source: "alkmaar" },
     raw: {},
   });
@@ -253,8 +259,16 @@ Deno.test("a Notubiz motion normalizes with an exact agenda-item link", async ()
   assert(motion.name.includes("Amendement"), "title from field 1");
   assertEquals(motion.status, "verworpen", "outcome from field 62");
   assertEquals(motion.result, "verworpen", "normalized result");
-  assertEquals(motion.agenda_item, canonicalAgendaItemId(source, 9977098), "exact agenda item link");
-  assertEquals(motion.meeting, "meeting:notubiz:gemeente:alkmaar:m1", "meeting resolved via agenda item");
+  assertEquals(
+    motion.agenda_item,
+    canonicalAgendaItemId(source, 9977098),
+    "exact agenda item link",
+  );
+  assertEquals(
+    motion.meeting,
+    "meeting:notubiz:gemeente:alkmaar:m1",
+    "meeting resolved via agenda item",
+  );
   assertEquals(motion.last_discussed_at, "2026-02-19T19:30:00Z", "dated by its meeting");
   assert((motion.parties?.length ?? 0) > 0, "submitting parties from field 37");
 
@@ -290,7 +304,12 @@ Deno.test("the outcome field wins over prose in the same field", () => {
   assertEquals(pick(attrs([[62, "aangenomen"]])), "aangenomen", "field 62 is preferred");
   // Some municipalities park prose in 62 and the real outcome in 71.
   assertEquals(
-    pick(attrs([[62, "gelijke stemming - wordt opnieuw in stemming gebracht"], [71, "verworpen"]])),
+    pick(
+      attrs([
+        [62, "gelijke stemming - wordt opnieuw in stemming gebracht"],
+        [71, "verworpen"],
+      ]),
+    ),
     "verworpen",
     "a decisive field wins over prose",
   );
@@ -307,7 +326,10 @@ class FakeIbabsClient {
   readonly meetingRangeCalls: Array<[string, string]> = [];
 
   constructor(
-    private readonly meetingsByDate: Record<string, Array<{ Id: string; MeetingDate: string; Title: string }>>,
+    private readonly meetingsByDate: Record<
+      string,
+      Array<{ Id: string; MeetingDate: string; Title: string }>
+    >,
     private readonly entries: Array<{ EntryId: string; MutationDate: string; agendapunt: string }>,
   ) {}
 
@@ -320,13 +342,15 @@ class FakeIbabsClient {
     const collected = [];
     for (const [date, meetings] of Object.entries(this.meetingsByDate)) {
       if (date >= from && date <= to) {
-        collected.push(...meetings.map((meeting) => ({
-          Id: meeting.Id,
-          MeetingtypeId: "t1",
-          MeetingDate: meeting.MeetingDate,
-          MeetingItems: [{ Id: `${meeting.Id}-item5`, Title: meeting.Title, Documents: [] }],
-          Documents: [],
-        })));
+        collected.push(
+          ...meetings.map((meeting) => ({
+            Id: meeting.Id,
+            MeetingtypeId: "t1",
+            MeetingDate: meeting.MeetingDate,
+            MeetingItems: [{ Id: `${meeting.Id}-item5`, Title: meeting.Title, Documents: [] }],
+            Documents: [],
+          })),
+        );
       }
     }
     return Promise.resolve(collected);
@@ -373,13 +397,29 @@ Deno.test("motions link to meetings outside the run window, fetching each date o
   // decided inside it. The first two share a meeting date.
   const client = new FakeIbabsClient(
     {
-      "2024-11-07": [{ Id: "old-meeting", MeetingDate: "2024-11-07T19:30:00", Title: "Programmabegroting" }],
-      "2026-07-16": [{ Id: "new-meeting", MeetingDate: "2026-07-16T19:30:00", Title: "Voorjaarsnota" }],
+      "2024-11-07": [
+        { Id: "old-meeting", MeetingDate: "2024-11-07T19:30:00", Title: "Programmabegroting" },
+      ],
+      "2026-07-16": [
+        { Id: "new-meeting", MeetingDate: "2026-07-16T19:30:00", Title: "Voorjaarsnota" },
+      ],
     },
     [
-      { EntryId: "e1", MutationDate: "2026-07-15T10:00:00", agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting" },
-      { EntryId: "e2", MutationDate: "2026-07-15T11:00:00", agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting" },
-      { EntryId: "e3", MutationDate: "2026-07-16T12:00:00", agendapunt: "Gemeenteraad 16-7-2026\\n5 Voorjaarsnota" },
+      {
+        EntryId: "e1",
+        MutationDate: "2026-07-15T10:00:00",
+        agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting",
+      },
+      {
+        EntryId: "e2",
+        MutationDate: "2026-07-15T11:00:00",
+        agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting",
+      },
+      {
+        EntryId: "e3",
+        MutationDate: "2026-07-16T12:00:00",
+        agendapunt: "Gemeenteraad 16-7-2026\\n5 Voorjaarsnota",
+      },
     ],
   );
 
@@ -419,10 +459,16 @@ Deno.test("motions_only skips the meeting pass but still links motions", async (
   const source = getIbabsSource("utrecht");
   const client = new FakeIbabsClient(
     {
-      "2024-11-07": [{ Id: "old-meeting", MeetingDate: "2024-11-07T19:30:00", Title: "Programmabegroting" }],
+      "2024-11-07": [
+        { Id: "old-meeting", MeetingDate: "2024-11-07T19:30:00", Title: "Programmabegroting" },
+      ],
     },
     [
-      { EntryId: "e1", MutationDate: "2026-07-15T10:00:00", agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting" },
+      {
+        EntryId: "e1",
+        MutationDate: "2026-07-15T10:00:00",
+        agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting",
+      },
     ],
   );
 
@@ -464,7 +510,9 @@ Deno.test("a motion projects into a searchable Quickwit document", async () => {
     await fixture("ibabs_list_entry_votes_response.xml"),
   );
   const meetings = new MeetingIndex();
-  meetings.add(meetingFixture("meeting:ibabs:gemeente:utrecht:m1", "Gemeenteraad", "2026-01-29T00:00:00Z"));
+  meetings.add(
+    meetingFixture("meeting:ibabs:gemeente:utrecht:m1", "Gemeenteraad", "2026-01-29T00:00:00Z"),
+  );
 
   const motion = normalizeIbabsMotion(source, list, entries[0], detail, votes, meetings);
   const event = await buildEntityCommitEvent(motion);
@@ -503,6 +551,56 @@ Deno.test("an unparseable date is dropped rather than passed to the index", asyn
   }
 });
 
+/** #203, and the reason it outlived its own fix.
+ *
+ * The suppliers' normalisers already convert a bare reading, but they only run
+ * at import time. The export log kept what they produced *before* that fix —
+ * readings like `2023-11-28 19:30:00` — and projection handed those straight
+ * to `new Date()`, which in a UTC container reads 19:30 as 19:30 UTC. Every
+ * meeting imported before the fix therefore claimed to start an hour or two
+ * later than it did, and one near midnight landed on the wrong day entirely.
+ *
+ * Converting here is what makes the backlog repairable without asking a
+ * supplier anything: the raw wall clock is still in the export log, so a
+ * reindex_only re-projects it correctly. */
+Deno.test("a zoneless start_date is projected as a Dutch wall clock, not as UTC", async () => {
+  const cases: Array<[string, string, string]> = [
+    ["2023-11-28 19:30:00", "2023-11-28T18:30:00Z", "winter is CET, so 19:30 is 18:30Z"],
+    ["2026-08-19T19:30:00", "2026-08-19T17:30:00Z", "summer is CEST, so 19:30 is 17:30Z"],
+    ["2026-08-19 19:30", "2026-08-19T17:30:00Z", "seconds are optional"],
+    // A reading that already carries a zone is trusted, not shifted again.
+    ["2026-08-19T17:30:00Z", "2026-08-19T17:30:00Z", "an explicit Z is left alone"],
+    ["2026-01-29T10:15:30+01:00", "2026-01-29T09:15:30Z", "an explicit offset is honoured"],
+    // Midnight is a date, not a moment: shifting it back would move a meeting
+    // to the previous day for every consumer that reads only the date part.
+    ["2026-08-19 00:00:00", "2026-08-19T00:00:00Z", "midnight stays put"],
+    ["2026-08-19", "2026-08-19T00:00:00Z", "a bare day stays put"],
+  ];
+
+  for (const [raw, expected, why] of cases) {
+    const meeting = meetingFixture("meeting:ibabs:gemeente:utrecht:m10", "Gemeenteraad", raw);
+    const event = await buildEntityCommitEvent(meeting);
+    const [projected] = projectEntityCommitToQuickwitDocuments(event);
+    assertEquals(projected.start_date, expected, `${why} (input ${JSON.stringify(raw)})`);
+  }
+});
+
+/** The bug's most damaging shape: an evening meeting stamped as UTC is read
+ * back an hour or two later, and one late enough tips over midnight into the
+ * next day — where a date filter for its actual day no longer finds it. */
+Deno.test("a late-evening meeting keeps its own day", async () => {
+  const meeting = meetingFixture(
+    "meeting:ibabs:gemeente:utrecht:m11",
+    "Gemeenteraad",
+    "2024-03-01 23:58:00",
+  );
+  const event = await buildEntityCommitEvent(meeting);
+  const [projected] = projectEntityCommitToQuickwitDocuments(event);
+
+  assertEquals(projected.start_date, "2024-03-01T22:58:00Z", "23:58 CET is 22:58Z");
+  assertEquals(projected.start_date?.slice(0, 10), "2024-03-01", "and stays on 1 March");
+});
+
 Deno.test("the backfill planner splits only where the cap demands it", async () => {
   const { __test__: planner } = await import("../scripts/plan_motion_backfill.ts");
 
@@ -525,12 +623,18 @@ Deno.test("a throttled meeting-type call fails a full run but not a motions_only
 
   class ThrottlingTypes extends FakeIbabsClient {
     override getMeetingTypes(): Promise<never> {
-      return Promise.reject(new Error("Request failed 403 for https://wcf.ibabs.eu/api/Public.svc"));
+      return Promise.reject(
+        new Error("Request failed 403 for https://wcf.ibabs.eu/api/Public.svc"),
+      );
     }
   }
 
   const entries = [
-    { EntryId: "e1", MutationDate: "2026-07-15T10:00:00", agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting" },
+    {
+      EntryId: "e1",
+      MutationDate: "2026-07-15T10:00:00",
+      agendapunt: "Gemeenteraad 7-11-2024\\n5 Programmabegroting",
+    },
   ];
   const meetings = {
     "2024-11-07": [{ Id: "m", MeetingDate: "2024-11-07T19:30:00", Title: "Programmabegroting" }],
@@ -540,14 +644,15 @@ Deno.test("a throttled meeting-type call fails a full run but not a motions_only
   const lenient = new ThrottlingTypes(meetings, entries);
   const motions: MotionEntity[] = [];
   // deno-lint-ignore no-explicit-any
-  const bundle = await new IbabsMeetingExtractor(lenient as any, () => Promise.resolve(undefined))
-    .extractForDateRange(source, "2026-07-14", "2026-07-18", {
-      executionMode: "motions_only",
-      retainEntities: false,
-      onEntity: (entity) => {
-        if (entity.type === "Motion") motions.push(entity);
-      },
-    });
+  const bundle = await new IbabsMeetingExtractor(lenient as any, () =>
+    Promise.resolve(undefined),
+  ).extractForDateRange(source, "2026-07-14", "2026-07-18", {
+    executionMode: "motions_only",
+    retainEntities: false,
+    onEntity: (entity) => {
+      if (entity.type === "Motion") motions.push(entity);
+    },
+  });
   assertEquals(motions.length, 1, "the motion is still imported");
   assert(bundle.stats.issue_count >= 1, "and the failure is reported, not swallowed");
 
@@ -557,8 +662,9 @@ Deno.test("a throttled meeting-type call fails a full run but not a motions_only
   let thrown: unknown;
   try {
     // deno-lint-ignore no-explicit-any
-    await new IbabsMeetingExtractor(strict as any, () => Promise.resolve(undefined))
-      .extractForDateRange(source, "2026-07-14", "2026-07-18", { retainEntities: false });
+    await new IbabsMeetingExtractor(strict as any, () =>
+      Promise.resolve(undefined),
+    ).extractForDateRange(source, "2026-07-14", "2026-07-18", { retainEntities: false });
   } catch (error) {
     thrown = error;
   }


### PR DESCRIPTION
Sluit de code-kant van #203. De data-kant volgt pas na een reindex, zie onderaan.

## Waarom dit nodig is terwijl #203 al een fix had

`supplierDateTimeToUtc` doet het goede, maar staat in de leverancier-normalisatoren en die draaien alléén bij import. Het export-log heeft trouw bewaard wat die vóór die fix opleverden: kale lezingen als `2023-11-28 19:30:00`. De projectie gaf die door aan `new Date()`, wat in een UTC-container 19:30 als 19:30 UTC leest.

Gemeten tegen productie op 2026-08-28, met de aanvangstijd die Notubiz in de vergadertitel zet als oracle:

| periode | vergaderingen | correct omgerekend |
|---|---:|---:|
| jan 2023 | 64 | 0 |
| mrt 2024 | 58 | 0 |
| jun 2025 | 56 | 0 |
| mrt 2026 | 67 | 0 |
| aug 2026 | 71 | **70** |

De fix werkt dus, hij heeft alleen nooit iets bereikt wat al geïndexeerd was.

De schade zit aan de randen van een dag. Een vergadering met `2024-03-01T23:58:00Z` wordt getoond als **2 maart** en beantwoordt een datumfilter voor de verkeerde dag — precies wat een datumfilter hoort te kloppen.

## Wat er verandert

`toIndexDateTime` haalt een lezing eerst door `supplierDateTimeToUtc`. Een lezing mét zone wordt vertrouwd, een kale lezing als Nederlandse wandklok gelezen, en middernacht blijft middernacht (een datum, geen moment — terugschuiven zou hem naar de vorige dag verplaatsen).

De oude `new Date()`-tak blijft als fallback voor vormen die de converter niet kent. Bewust: de twee faalwijzen zijn niet symmetrisch. Een onparseerbare waarde laat Quickwit de héle entiteit weggooien (#184), een iets verkeerde kost één slecht gesorteerde rij.

## Te beoordelen: dit is breder dan alleen vergaderingen

Documenten leiden hun `start_date` af van `last_discussed_at`, en dat veld staat óók als kale lezing in het export-log — ook in verse commits, want de leverancier-normalisator raakt het niet aan.

Zodra dit live staat verschuift de geïndexeerde datum van élk document dat opnieuw geprojecteerd wordt met één of twee uur, geleidelijk via de dagelijkse imports. Dat is de correctie en geen regressie, maar het is meer dan "vergaderingen na een reindex", en het leek me niet iets om ongemerkt te laten gebeuren.

Vergaderingen die ná de eerdere fix zijn geïmporteerd blijven ongemoeid: die dragen al een `Z`.

`toDocumentMonth` heb ik niet aangeraakt. Die leidt uit dezelfde datum een maand af met dezelfde `new Date()`, dus rond een maandgrens kunnen maand en datum straks een uur uit elkaar liggen. Losse afweging, geen onderdeel van deze PR.

## Waarom hier en niet alleen bij import

Dit is wat de achterstand repareerbaar maakt zonder de leveranciers te bevragen: de ruwe wandklok staat nog in het export-log, dus een `reindex_only` projecteert hem correct.

Let op de volgorde: **een reindex zónder deze wijziging reproduceert exact dezelfde foute waarde**, want de projectie is de plek waar het misgaat.

## Verificatie

311 tests groen (2 nieuw), formattering en lint schoon. De bestaande test die `"onzin"` en `"2024-13-45"` op `undefined` pint blijft gelden.

## Daarna

De reindex is een aparte beslissing en zit niet in deze PR. Die raakt de hele index, en volgens de operationele aantekeningen is het split-cache-budget ongeveer gelijk aan de indexgrootte — nul speling — dus dat is niets voor een willekeurig moment.
