### PR TITLE
Point the monitor at the index we actually serve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Current implemented slices:
   variant — the .ts variant is a local tool) checks search latency, disk,
   containers, import health (stalled pipeline, stuck queue, extraction failure
   surges), and backup freshness. Runs every 2 min via `woozi-monitor.timer`.
+- The monitor must watch the index the app actually serves. Its split-cache janitor deletes every cached split absent from `QUICKWIT_INDEX_ID`'s metastore, so pointing it at the wrong index does not degrade a check — it deletes the live cache. That is what happened between 2026-08-12 and 2026-08-30: the monitor's own default still said `woozi-events-prod` after the projection moved to `woozi-events-v3b`, so 53G of cache sat on a frozen index nobody queries while every live split was removed within two minutes of being fetched. It now follows `QUICKWIT_INDEX_ID` from the same `.env` the app reads. Bump the projection index and the monitor follows; override only via `WOOZI_MONITOR_QUICKWIT_INDEX_ID`.
 - The SQLite state (ops + export log) is backed up daily to S3 via
   `woozi-backup.timer` running `scripts/backup_state.ts` inside the web
   container (14-day retention, `backups/sqlite/` prefix). Install with

--- a/scripts/monitor-production.sh
+++ b/scripts/monitor-production.sh
@@ -58,7 +58,27 @@ QUICKWIT_SPLIT_CACHE_POLLUTION_RATIO="${WOOZI_MONITOR_QUICKWIT_SPLIT_CACHE_POLLU
 # cached files (below this floor, so the janitor never ran) of which 40 were
 # orphans, occupying 44G of the 55G budget and evicting live splits.
 QUICKWIT_SPLIT_CACHE_POLLUTION_MIN_FILES="${WOOZI_MONITOR_QUICKWIT_SPLIT_CACHE_POLLUTION_MIN_FILES:-150}"
-QUICKWIT_INDEX_ID="${WOOZI_MONITOR_QUICKWIT_INDEX_ID:-woozi-events-prod}"
+# The index to watch. Follows the one the application and workers actually
+# serve -- QUICKWIT_INDEX_ID from /opt/woozi/.env, which systemd hands us via
+# EnvironmentFile -- because here the two drifting apart is not cosmetic: this
+# name selects the metastore that decides which cached splits are orphans.
+#
+# It used to be a bare default, and nothing ever set
+# WOOZI_MONITOR_QUICKWIT_INDEX_ID, so the monitor watched woozi-events-prod
+# while the app moved to woozi-events-v3b on 2026-08-12. The janitor below
+# then protected 92 splits of a frozen index nobody queries, and treated every
+# split of the *served* index as an orphan -- deleting each one within two
+# minutes of the searcher fetching it. Measured 2026-08-30 in a quiet period:
+# 50 of 50 cached splits belonged to prod and 0 to v3b, 53G of cache spent on
+# splits no query touches, while the cache could never retain a live one.
+#
+# That is the standing cause behind the chronic "Search is slow" alerts (115
+# in the preceding week). It only looked like an incident when a reindex made
+# the searcher fetch live splits faster than the janitor deleted them.
+#
+# The same name feeds the cold-cache threshold below, so its "what there is to
+# cache" denominator was measured against the wrong index too.
+QUICKWIT_INDEX_ID="${WOOZI_MONITOR_QUICKWIT_INDEX_ID:-${QUICKWIT_INDEX_ID:-woozi-events-prod}}"
 QUICKWIT_INDEX_ROOT_PREFIX="${WOOZI_MONITOR_QUICKWIT_INDEX_ROOT_PREFIX:-indexes-prod}"
 # Floor between two cache purges regardless of how often the ratio trips —
 # the purge itself resets the ratio to ~1x, so this only guards against a


### PR DESCRIPTION
Eén regel, maar een destructieve.

## Wat er misging

De split-cache-janitor verwijdert elk cachebestand dat niet als `Published` in de metastore van `QUICKWIT_INDEX_ID` staat. Die naam bepaalt dus wát er wordt weggegooid — het is een destructieve instelling, geen rapportage-instelling.

Hij werd afgeleid van `WOOZI_MONITOR_QUICKWIT_INDEX_ID`, en dat is nooit ergens gezet. `/opt/woozi/.env` zet wél `QUICKWIT_INDEX_ID=woozi-events-v3b` en systemd geeft die door via `EnvironmentFile`, maar de toekenning overschreef hem met de eigen default `woozi-events-prod`.

Sinds de projectie op 2026-08-12 naar `woozi-events-v3b` verhuisde, beschermde de janitor dus 92 splits van een bevroren index die niemand bevraagt, en zag hij elke split van de bediende index als weesbestand — verwijderd binnen twee minuten nadat de searcher hem had opgehaald.

## Meting

Op 2026-08-30, in een rustige periode, dus niet tijdens een storm:

```
cachebestanden       50
  van prod           50      beschermd, wordt nooit bevraagd
  van v3b             0      wordt bevraagd, blijft nooit staan
```

53 GB van een budget van 120 GB, volledig besteed aan splits die geen enkele query raakt. De cache kon structureel geen enkele levende split vasthouden.

De twee indexen:

| | prod | v3b |
|---|---|---|
| laatste split | 2026-08-12 03:31 | 2026-08-31 00:23 |
| `start_date` in mapping | niet gemapt | `datetime`, fast field |
| splits op S3 | 71,1 GB | 62,4 GB |

## Waarom dit meer is dan één incident

Dit is de staande oorzaak achter de chronische traagheid: **115 "Search is slow"-alerts in de week ervoor.** Het viel pas op als incident toen een reindex de searcher sneller live splits liet ophalen dan de janitor ze kon verwijderen — toen vuurde `quickwit_cache_cold` 29 keer op één dag, voor het eerst.

Dezelfde variabele voedt ook de cold-cache-drempel eronder, dus de noemer "wat er te cachen valt" werd óók tegen de verkeerde index gemeten. `cacheable_gb=66` in die alerts was prod, niet v3b.

## De wijziging

```bash
QUICKWIT_INDEX_ID="${WOOZI_MONITOR_QUICKWIT_INDEX_ID:-${QUICKWIT_INDEX_ID:-woozi-events-prod}}"
```

De monitor volgt nu de index die de app bedient, met de expliciete override intact. Geverifieerd voor alle drie de gevallen: `.env` gezet → `v3b`; override gezet → override wint; niets gezet → laatste redmiddel.

## Wat er gebeurt bij uitrol

De 50 prod-splits worden dan terecht als weesbestanden gezien en in één veeg verwijderd: ~53 GB cache weg, gevolgd door een koude periode terwijl v3b-splits binnenkomen. Kortstondig trager, daarna voor het eerst een cache die doet waarvoor hij bedoeld is.

Ik zou dit dus buiten kantooruren uitrollen, en daarna verifiëren dat de cache zich met v3b-splits vult in plaats van met prod.

## Bewust niet gedaan

Geen extra rem van het type "waarschuw als de veegbeurt bijna de hele cache raakt". Na een echte projectie-bump zíjn vrijwel alle gecachete splits weesbestanden, dus die heuristiek zou juist afgaan wanneer de janitor het hardst nodig is. Weigeren te handelen op een onleesbare metastore zit er al in.

`woozi-events-prod` opruimen is een aparte beslissing en zit hier niet in. Volgorde is wel bindend: eerst dit, anders wijst de janitor straks naar een niet-bestaande metastore.
