### PR TITLE
Tell crawlers and models what is here and where to find it

### DIFF
--- a/web/llms.txt
+++ b/web/llms.txt
@@ -1,0 +1,49 @@
+# OpenBesluitvorming
+
+> Doorzoek de openbare besluitvorming van Nederlandse gemeenten, provincies en
+> waterschappen: vergaderstukken, agenda's, besluiten, moties en verslagen uit
+> ruim 300 bestuursorganen, dagelijks bijgewerkt bij de bron.
+
+De collectie bestaat uit stukken die de bestuursorganen zelf publiceren in hun
+raadsinformatiesystemen (Notubiz, iBabs, GemeenteOplossingen, Parlaeus). Deze
+dienst haalt ze op, maakt de tekst doorzoekbaar en houdt de herkomst intact:
+elk resultaat verwijst naar het originele document bij de bron.
+
+Dit is de opvolger van Open Raadsinformatie. Zie de migratiegids hieronder.
+
+## Zoeken
+
+- [Zoekpagina](https://openbesluitvorming.nl/): zoeken op onderwerp, met filters op
+  bestuursorgaan, type, datum en sortering. Een zoekopdracht staat volledig in de
+  URL, dus een link naar een zoekresultaat blijft werken.
+- Een frase zoek je tussen dubbele aanhalingstekens: `"sociale huurwoningen"`.
+  Nabijheidszoeken (`"a b"~10`) wordt niet ondersteund en levert een foutmelding
+  in plaats van een ander antwoord.
+
+## API
+
+- [API-documentatie](https://openbesluitvorming.nl/docs/api) (Engelstalig): endpoints,
+  parameters, foutcodes en tariefgrenzen.
+- `GET /api/search` — zoeken, met `query`, `organization`, `entityType`, `sort`,
+  `dateFrom`, `dateTo`, `offset` en `limit`.
+- `GET /api/entities/{id}` — één vergadering, document, motie of opname, inclusief
+  de volledige geëxtraheerde tekst.
+- `GET /api/sources` — de bestuursorganen die worden geïndexeerd.
+- `GET /api/status` — actualiteit per bron: wanneer er voor het laatst met succes is
+  bijgewerkt.
+- `GET /api/export/snapshot` en `/api/export/changes` — bulk ophalen en synchroniseren.
+  Dit is de bedoelde route voor wie de collectie in zijn geheel wil, niet de zoek-API.
+
+Elke foutmelding draagt een stabiele `code` naast de Nederlandse tekst; zie de
+foutcodetabel in de API-documentatie. Match op `code`, niet op de tekst.
+
+## Voor hergebruikers van Open Raadsinformatie
+
+- [Migratiegids](https://openbesluitvorming.nl/docs/migration-guide) (Engelstalig):
+  hoe de oude ORI-API zich verhoudt tot deze.
+
+## Wat deze dienst niet is
+
+Geen officiële bekendmaking en geen archief met rechtskracht. De bron blijft het
+bestuursorgaan zelf; een document dat daar wordt ingetrokken of vervangen, kan
+hier nog even zichtbaar zijn. Voor de geldende versie: volg de link naar de bron.

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,24 @@
+# openbesluitvorming.nl — doorzoek de openbare besluitvorming van Nederlandse
+# gemeenten, provincies en waterschappen.
+#
+# Crawlen is welkom. Deze stukken zijn openbaar en juist bedoeld om gevonden
+# te worden; tot voor kort was er geen enkele link naar een document om te
+# volgen, wat de hele collectie buiten het bereik van zoekmachines hield.
+# Wat hieronder dicht staat, staat dicht omdat crawlen er niets oplevert.
+
+User-agent: *
+Allow: /
+
+# De beheeromgeving zit achter authenticatie en heeft geen publieke inhoud.
+Disallow: /admin
+
+# Bulk-export levert NDJSON van megabytes per pagina: nuttig voor een
+# hergebruiker, zinloos voor een index, en duur om te serveren. Wie de
+# volledige collectie wil, leest /docs/api en gebruikt deze endpoints
+# rechtstreeks in plaats van ze te crawlen.
+Disallow: /api/export/
+
+# De overige /api/-adressen blijven bewust open. De site rendert een document
+# in de browser via die endpoints, dus een crawler die ze niet mag ophalen
+# ziet een lege pagina — precies het tegenovergestelde van wat dit bestand
+# moet bereiken.

--- a/web/server.ts
+++ b/web/server.ts
@@ -251,6 +251,10 @@ function contentType(pathname: string): string {
   if (pathname.endsWith(".png")) return "image/png";
   if (pathname.endsWith(".ico")) return "image/x-icon";
   if (pathname.endsWith(".woff2")) return "font/woff2";
+  // robots.txt and llms.txt are read by machines that check the type. The
+  // fallthrough below is text/html, which makes a crawler treat a directive
+  // file as a document and ignore it.
+  if (pathname.endsWith(".txt")) return "text/plain; charset=utf-8";
   if (pathname.endsWith(".svg")) return "image/svg+xml";
   return "text/html; charset=utf-8";
 }


### PR DESCRIPTION
Sluit #207 en #208. #209 zit er bewust niet in, zie onderaan.

## robots.txt (#207)

Nodigt uit tot crawlen, want dat is het punt: dit zijn openbare stukken, en tot #212 elk resultaat een `<a href>` gaf viel er voor een crawler überhaupt niets te volgen.

Dicht staat alleen wat crawlen niet kan gebruiken:

- `/admin` — achter authenticatie, geen publieke inhoud.
- `/api/export/` — NDJSON-pagina's van megabytes, waardeloos voor een index en duur om te serveren. Wie de collectie in bulk wil, leest `/docs/api`.

**De rest van `/api/` blijft bewust open.** De reader rendert een document in de browser via die endpoints, dus een crawler die ze niet mag ophalen ziet een lege pagina — precies het omgekeerde van wat dit bestand moet bereiken. Dat is de val waar een `Disallow: /api/` in loopt.

Geen `Sitemap:`-regel. Het issue vraagt erom, maar er ís nog geen sitemap; naar een 404 wijzen is slechter dan zwijgen. Die regel hoort bij de sitemap zelf, in #206.

## llms.txt (#208)

Beschrijft de collectie, benoemt de endpoints, en zegt expliciet wat deze dienst *niet* is: geen officiële bekendmaking, geen archief met rechtskracht, en een document dat bij de bron wordt ingetrokken kan hier nog even staan.

Dat laatste is de reden dat het er staat. Een model dat dit corpus samenvat moet dat voorbehoud meedragen, en het is precies het ene ding dat het niet uit de data kan afleiden.

## Content-type

`.txt` viel door naar `text/html`. Beide bestanden zouden dus zijn geserveerd en stilzwijgend genegeerd — een crawler die een richtlijnenbestand als document aangeboden krijgt, doet er niets mee. Nu `text/plain`.

## Waarom #209 hier niet in zit

`security.txt` heeft een `Contact:` nodig, en het enige adres op de site is dat van Sander Bakker bij VNG, nu gebruikt voor privacy- en takedown-vragen. Iemand aanwijzen als ontvanger van securitymeldingen is een afspraak met die persoon, geen redactiekeuze. Dat leg ik voor in plaats van het in te vullen.

## Verificatie

311 tests groen. `COPY web ./web` in `Dockerfile.web` neemt beide bestanden mee, en `readStaticFile` valt terug op `web/` als iets niet in `dist/` staat. Ik verifieer beide URL's tegen productie zodra dit is uitgerold.
