### PR TITLE
Let the next index choose its disk and its commit cadence

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -433,6 +433,29 @@ matching where the live index already is. Two things to know:
   for `woozi-events-prod`; it only decides where the next index goes. Verify with
   `GET /api/v1/indexes/<id>` and look at `index_uri` before trusting a rebuild.
 
+### Creating an index somewhere else than the node default
+
+`ensureIndex` posts `quickwit/index-config.json` verbatim, so on its own every
+new index inherits the node's `default_index_root_uri` (S3 on production) and
+the file's `commit_timeout_secs: 1`. Three environment variables, read by the
+container that creates the index, override that at creation time and are
+ignored for an index that already exists:
+
+| variable | effect |
+|---|---|
+| `QUICKWIT_INDEX_URI` | sets `index_uri`, e.g. `file:///quickwit/qwdata/indexes-prod/woozi-events-v4` |
+| `QUICKWIT_COMMIT_TIMEOUT_SECS` | sets `indexing_settings.commit_timeout_secs` |
+| `QUICKWIT_INGEST_COMMIT` | `auto`, `wait_for` (default) or `force` on every ingest request |
+
+On production the worker takes them from `WORKER_QUICKWIT_INDEX_URI`,
+`WORKER_QUICKWIT_COMMIT_TIMEOUT_SECS` and `QUICKWIT_INGEST_COMMIT` in
+`/opt/woozi/.env`. Verify with `GET /api/v1/indexes/<id>` after the first
+worker run: `index_uri` and `commit_timeout_secs` are what the index will keep.
+
+`wait_for` and a sane commit timeout do not mix for bulk work: every batch then
+waits the full timeout (measured 60s per batch at 60, on 0.9.0, regardless of
+how many batches are in flight). Reindex campaigns want `auto`.
+
 ### Cutting over without emptying search
 
 Switching both containers at once empties search for as long as the reindex

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -150,6 +150,15 @@ services:
       # to the served values, so unset changes nothing.
       QUICKWIT_INDEX_ID: ${WORKER_QUICKWIT_INDEX_ID:-${QUICKWIT_INDEX_ID:-woozi-events-prod}}
       WOOZI_PROJECTION_VERSION: ${WORKER_PROJECTION_VERSION:-${WOOZI_PROJECTION_VERSION:-}}
+      # Only consulted when the worker *creates* an index (a new id above).
+      # Unset, the node's default_index_root_uri (S3) and the checked-in
+      # commit_timeout_secs (1) apply -- both of which the next index must not
+      # inherit. See docs/local-index-plan.md.
+      QUICKWIT_INDEX_URI: ${WORKER_QUICKWIT_INDEX_URI:-}
+      QUICKWIT_COMMIT_TIMEOUT_SECS: ${WORKER_QUICKWIT_COMMIT_TIMEOUT_SECS:-}
+      # auto | wait_for | force. wait_for blocks each batch for a full
+      # commit_timeout_secs; set auto for a corpus-wide reindex.
+      QUICKWIT_INGEST_COMMIT: ${QUICKWIT_INGEST_COMMIT:-wait_for}
       QUICKWIT_BATCH_SIZE: ${QUICKWIT_BATCH_SIZE:-64}
       # iBabs rate limits are per IP address and the whole fleet shares one, so
       # each worker may only pace itself to its share of the budget. Without

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,8 @@ services:
 
   # Does the search, needs an S3 bucket and a volume
   quickwit:
-    image: quickwit/quickwit:0.8.1
+    # Override to try a newer Quickwit locally, e.g. QUICKWIT_IMAGE=quickwit/quickwit:0.9.0.
+    image: ${QUICKWIT_IMAGE:-quickwit/quickwit:0.8.1}
     command:
       - run
       - --config

--- a/docs/local-index-plan.md
+++ b/docs/local-index-plan.md
@@ -1,0 +1,198 @@
+# The next index: local storage, one operation
+
+Date: 2026-09-02. Plan for the projection index that replaces
+`woozi-events-v3b`. Background in
+[`search-performance-quickwit-s3.md`](search-performance-quickwit-s3.md) (why)
+and [`handover-split-cache-and-reindex.md`](handover-split-cache-and-reindex.md)
+(what happened since). This document is the how, with the measurements that
+changed the plan.
+
+## What it settles
+
+Three open items are one fresh index:
+
+1. **#203, the timezone backlog.** Rows projected before 2026-08-28 carry a
+   `start_date` two hours off. Re-projecting into the live index appends a
+   second row with the same `time`, and the tie goes to whichever row Quickwit
+   returns first. Only an empty index replaces anything.
+2. **The split churn.** `commit_timeout_secs: 1` on an S3-backed index is why
+   the searcher split cache exists, and the cache is why 150 lines of
+   monitor script exist. A local index with a normal commit cadence needs
+   neither.
+3. **The duplicates** left by timed-out ingests during the v3b campaign and by
+   the 2026-08-28 trial reindex of `dongen`.
+
+## Measurements that changed the plan
+
+### The index will not shrink 3.5x
+
+The July estimate assumed query-time dedup would collapse the index. It
+already did that once: v3b *is* a fresh reindex. Measured 2026-09-02:
+
+| | rows |
+|---|---|
+| `woozi-events-v3b`, all rows | 44,647,042 |
+| of which `DocumentPage` | 38,629,780 (86%) |
+| of which `Document` | 5,623,682 |
+| other primary rows | 393,580 |
+| export log, unique entities | 5,570,607 |
+
+Primary rows exceed unique entities by about 8%; those are the duplicates.
+Page rows are the index, and a fresh projection produces the same pages. A v4
+with the same doc mapping lands around **57-60 GB**, not 18. The real shrink
+is Option C in the July document (stop storing `content` per page, map
+explicitly) and that is a product change with its own tests. It is not part
+of this operation.
+
+### Where the splits can go
+
+| disk | size | free | 4K random read |
+|---|---|---|---|
+| `/dev/sda` root, NVMe | 150 GB | 101 GB | 0.22 ms |
+| `/dev/sdb` volume, `/mnt/quickwit-cache` | 147 GB | 79 GB | 2.01 ms |
+
+Root cannot take it. A 60 GB index plus merge headroom (the four largest v3b
+splits are 12-18 GB each; a merge holds inputs and output at once) plus the
+indexer's own split store peaks near the free space, and the 2026-08-10
+incident was exactly a root disk filling under a reindex.
+
+The volume can, and its slowness is a non-issue for a reason the compose
+comment missed: the split cache lives on that volume today, so every warm
+search already reads splits from `/dev/sdb`. A local index there performs
+like today's warm cache, with no cold misses to S3. The measured 0.39-0.43s
+on `/api/search` is `/dev/sdb` performance.
+
+So: the index goes on the volume, and the volume stops being a cache.
+
+### Quickwit 0.9.0
+
+Released 2026-07-25 (five weeks before this document). Tested locally against
+our `quickwit.yaml` and `index-config.json`:
+
+- boots on the checked-in node config unchanged;
+- `PUT /api/v1/indexes/<id>` updates `commit_timeout_secs` on an existing
+  index. Verified: 60 to 90 on a live index. **This means the churn on v3b can
+  be stopped the day of the upgrade, before any reindex.**
+- the file metastore is rewritten to format `0.9` on first write; back it up
+  first, there is no downgrade;
+- ingest V2 serves `/api/v1/<id>/ingest`. With `commit=wait_for` every batch
+  waits the full `commit_timeout_secs`: measured 62s for one batch and 60s for
+  four parallel batches at a timeout of 60. `commit=auto` returns in 20 ms.
+  The worker's default stays `wait_for`; the campaign runs with
+  `QUICKWIT_INGEST_COMMIT=auto`;
+- the searcher split cache wraps **every** storage, file:// included. A
+  local index would be copied into the cache split by split, doubling disk.
+  `max_num_bytes: 0` does not disable it (verified: still caches). Disabling
+  means removing the `searcher.split_cache` section from `quickwit.yaml`.
+
+### The ingest client
+
+`ensureIndex` posts the checked-in config verbatim, so a new index inherits
+the node's S3 root and `commit_timeout_secs: 1`. Since this change the worker
+honours `QUICKWIT_INDEX_URI`, `QUICKWIT_COMMIT_TIMEOUT_SECS` and
+`QUICKWIT_INGEST_COMMIT` at creation and ingest time; production sets them per
+worker through `WORKER_QUICKWIT_INDEX_URI`,
+`WORKER_QUICKWIT_COMMIT_TIMEOUT_SECS` and `QUICKWIT_INGEST_COMMIT` in
+`/opt/woozi/.env`. Verified end to end against 0.9.0: an index created with
+`file://` URI and timeout 90 reports exactly that from `GET /api/v1/indexes`.
+
+## Sequence
+
+Each step has a check that decides whether the next one happens.
+
+**0. Before touching anything.** `df` on both disks, the phantom check
+(tally against disk) at zero, and a copy of
+`/quickwit/qwdata/indexes-prod/woozi-events-v3b/metastore.json` outside the
+container. Note the current `/api/search` latency for comparison.
+
+**1. Upgrade Quickwit to 0.9.0.** Change the image tag in
+`docker-compose.production.yml`, deploy, restart Quickwit by hand (the deploy
+does not). Search is unavailable for seconds. Check: `/api/v1/version` says
+0.9.0, a phrase query and a date-sorted query against v3b return what they
+returned before, the workers' next import succeeds. Rollback: the 0.8.1 tag
+plus the metastore copy from step 0.
+
+**2. Stop the churn on v3b.** `PUT /api/v1/indexes/woozi-events-v3b` with
+`commit_timeout_secs: 60`. Check: the index config reports 60; over the next
+hour the number of published splits stops climbing between merges. This alone
+removes most of what the split cache machinery exists for, and it holds even
+if the reindex is postponed.
+
+**3. Make room on the volume.** Lower
+`QUICKWIT_SPLIT_CACHE_MAX_NUM_BYTES` to 40G for the duration and restart
+Quickwit, so v3b keeps a warm working set while v4 grows next to it. Bind-mount
+a second directory of the same volume into the container as the future index
+path:
+
+```yaml
+- /mnt/quickwit-cache/indexes/woozi-events-v4:/quickwit/qwdata/indexes-prod/woozi-events-v4
+```
+
+Check: `df` shows at least 100 GB free on the volume after the cache settles.
+
+**4. Create v4 by pointing only the workers at it.**
+
+```sh
+# /opt/woozi/.env
+WORKER_QUICKWIT_INDEX_ID=woozi-events-v4
+WORKER_PROJECTION_VERSION=search-v4-local
+WORKER_QUICKWIT_INDEX_URI=file:///quickwit/qwdata/indexes-prod/woozi-events-v4
+WORKER_QUICKWIT_COMMIT_TIMEOUT_SECS=60
+QUICKWIT_INGEST_COMMIT=auto
+```
+
+Restart the workers. Check, before any reindex is queued:
+`GET /api/v1/indexes/woozi-events-v4` shows the `file://` URI and timeout 60,
+and `du` on the bind-mounted directory starts moving with the first daily
+import. If the URI is wrong, delete the index now; it is empty.
+
+**5. Reindex one source, then all.** `reindex_only` on `dongen` first, as the
+2026-08-28 trial did, and compare meeting counts with the export log. Then
+every source, with the same worker count as the v3b campaign (four workers,
+eight jobs). Last time: 10.4 hours for 5.28M documents. Watch: volume free
+space, ingest 413s in the worker logs, and the shape of the split count (it
+should climb slowly and merge down, not sawtooth by the second).
+
+**6. Verify v4.** Rows per entity type against the table above minus the
+duplicate share; per-source meeting counts against the export log for a
+sample of ten sources; the three Dongen meetings from #203 showing one row
+each with the corrected date; a phrase query, a date range, a date sort.
+
+**7. Cut over the reader.** `QUICKWIT_INDEX_ID=woozi-events-v4` and
+`WOOZI_PROJECTION_VERSION=search-v4-local` on the web container, restart it.
+That is the only moment users notice anything. Check: `/api/search` latency
+at or below step 0, the monitor's index follows automatically.
+
+**8. Delete what the local index makes irrelevant.** One pull request:
+
+- `searcher.split_cache` section out of `quickwit.yaml`; the split-cache
+  environment out of the compose file; the `/mnt/quickwit-cache` bind mount
+  over `searcher-split-cache` out;
+- the split-cache block out of `monitor-production.sh`: the phantom check,
+  the purge, the cooldown, the orphan report, the cold-cache check, and all
+  `WOOZI_MONITOR_QUICKWIT_SPLIT_CACHE_*` and `QUICKWIT_CACHE_COLD_PERCENT`
+  settings;
+- the six Quickwit split-cache series out of the collector config, and the
+  `/mnt/quickwit-cache` mountpoint entry stays (it now holds the index);
+- the AGENTS.md paragraphs about never deleting from the split cache, reduced
+  to one line saying the index is local and why.
+
+Restart Quickwit once more with the cache section gone. Check: the cache
+directory stays empty across a day of searches.
+
+**9. Retire v3b.** Keep it a week. Then `DELETE /api/v1/indexes/woozi-events-v3b`
+and remove its S3 prefix. The v3b metastore copy from step 0 stays on the host
+like the prod one does.
+
+## What can go wrong
+
+- **The volume fills during the campaign.** v3b cache at 40G plus v4 at 60G
+  plus merge headroom is near 147G. Mitigation: step 3's check, and the
+  campaign can pause (the queue is durable) while the cache budget drops
+  further; v3b keeps serving from S3 at cold-cache speed.
+- **Ingest V2 throughput.** V2 paces per shard; whether the campaign hits that
+  ceiling is not known until step 5's single-source run. If it is much slower
+  than v3b's campaign, `commit=force` per batch is not the answer (that is
+  churn again); more shards or a larger batch are.
+- **Something on the 0.9 read path differs.** Step 1's check is a full pass
+  of the search test suite against production, not one query.

--- a/src/quickwit/client.ts
+++ b/src/quickwit/client.ts
@@ -115,6 +115,78 @@ function getIndexId(): string {
   return Deno.env.get("QUICKWIT_INDEX_ID") ?? DEFAULT_INDEX_ID;
 }
 
+function envOrUndefined(name: string): string | undefined {
+  const value = Deno.env.get(name)?.trim();
+  return value ? value : undefined;
+}
+
+export type IndexConfigOverrides = {
+  indexId: string;
+  /** Where the splits go. Unset leaves it to the node's
+   * `default_index_root_uri`, which on production is S3. */
+  indexUri?: string;
+  /** Seconds between commits. The checked-in config says 1, which is what
+   * produced the split churn described in docs/search-performance-quickwit-s3.md;
+   * the next index wants 60-120. */
+  commitTimeoutSecs?: number;
+};
+
+/** The checked-in index config is shared by dev, tests and production, so the
+ * per-deployment choices -- id, storage location, commit cadence -- are made
+ * here, at creation time, from the environment. Nothing here changes an index
+ * that already exists; see `ensureIndex`. */
+export function applyIndexConfigOverrides(
+  config: Record<string, unknown>,
+  overrides: IndexConfigOverrides,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...config, index_id: overrides.indexId };
+  if (overrides.indexUri) {
+    result.index_uri = overrides.indexUri;
+  }
+  if (overrides.commitTimeoutSecs !== undefined) {
+    const settings = (config.indexing_settings ?? {}) as Record<string, unknown>;
+    result.indexing_settings = { ...settings, commit_timeout_secs: overrides.commitTimeoutSecs };
+  }
+  return result;
+}
+
+function getIndexConfigOverridesFromEnv(indexId: string): IndexConfigOverrides {
+  const raw = envOrUndefined("QUICKWIT_COMMIT_TIMEOUT_SECS");
+  const commitTimeoutSecs = raw === undefined ? undefined : Number(raw);
+  if (
+    commitTimeoutSecs !== undefined &&
+    !(Number.isInteger(commitTimeoutSecs) && commitTimeoutSecs > 0)
+  ) {
+    throw new Error(
+      `QUICKWIT_COMMIT_TIMEOUT_SECS must be a positive integer, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return {
+    indexId,
+    indexUri: envOrUndefined("QUICKWIT_INDEX_URI"),
+    commitTimeoutSecs,
+  };
+}
+
+const INGEST_COMMIT_MODES = ["auto", "wait_for", "force"] as const;
+type IngestCommitMode = (typeof INGEST_COMMIT_MODES)[number];
+
+/** `wait_for` holds the response until the batch is committed, which with a
+ * sane `commit_timeout_secs` means every batch takes the full timeout
+ * (measured on 0.9.0: 60s per batch at 60, four parallel batches all 60s).
+ * That is fine for the steady trickle of daily imports and hopeless for a
+ * corpus-wide reindex, which wants `auto`: the request returns once the rows
+ * are in Quickwit's durable queue, and the indexer commits on its own clock. */
+export function getIngestCommitMode(): IngestCommitMode {
+  const value = envOrUndefined("QUICKWIT_INGEST_COMMIT") ?? "wait_for";
+  if (!(INGEST_COMMIT_MODES as readonly string[]).includes(value)) {
+    throw new Error(
+      `QUICKWIT_INGEST_COMMIT must be one of ${INGEST_COMMIT_MODES.join(", ")}, got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as IngestCommitMode;
+}
+
 function getSearchTimeoutMs(): number {
   const value = Number(Deno.env.get("QUICKWIT_SEARCH_TIMEOUT_MS") ?? DEFAULT_SEARCH_TIMEOUT_MS);
   return Number.isFinite(value) && value > 0 ? value : DEFAULT_SEARCH_TIMEOUT_MS;
@@ -172,8 +244,10 @@ export class QuickwitClient {
   }
 
   async ensureIndex(configPath: string): Promise<void> {
-    const config = JSON.parse(await Deno.readTextFile(configPath)) as Record<string, unknown>;
-    config.index_id = this.indexId;
+    const config = applyIndexConfigOverrides(
+      JSON.parse(await Deno.readTextFile(configPath)) as Record<string, unknown>,
+      getIndexConfigOverridesFromEnv(this.indexId),
+    );
     const configText = JSON.stringify(config);
     const list = await fetchJson<
       Array<{ index_id?: string; index_config?: { index_id?: string } }>
@@ -249,7 +323,7 @@ export class QuickwitClient {
     for (let attempt = 1; attempt <= INGEST_ATTEMPTS; attempt += 1) {
       try {
         const response = await fetch(
-          `${this.baseUrl}/api/v1/${this.indexId}/ingest?commit=wait_for`,
+          `${this.baseUrl}/api/v1/${this.indexId}/ingest?commit=${getIngestCommitMode()}`,
           {
             method: "POST",
             headers: {

--- a/tests/quickwit_index_config.test.ts
+++ b/tests/quickwit_index_config.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { applyIndexConfigOverrides, getIngestCommitMode } from "../src/quickwit/client.ts";
+
+const checkedIn = JSON.parse(
+  await Deno.readTextFile(new URL("../quickwit/index-config.json", import.meta.url)),
+) as Record<string, unknown>;
+
+Deno.test("the checked-in config still carries the churn-producing commit timeout", () => {
+  // Documented, not endorsed: the next index must override this at creation.
+  const settings = checkedIn.indexing_settings as Record<string, unknown>;
+  assertEquals(settings.commit_timeout_secs, 1);
+  assertEquals("index_uri" in checkedIn, false);
+});
+
+Deno.test("only the id is patched when nothing else is asked for", () => {
+  const result = applyIndexConfigOverrides(checkedIn, { indexId: "woozi-events-x" });
+  assertEquals(result.index_id, "woozi-events-x");
+  assertEquals("index_uri" in result, false);
+  assertEquals(result.indexing_settings, checkedIn.indexing_settings);
+  assertEquals(result.doc_mapping, checkedIn.doc_mapping);
+});
+
+Deno.test("index_uri and commit_timeout_secs are applied without touching the rest", () => {
+  const result = applyIndexConfigOverrides(checkedIn, {
+    indexId: "woozi-events-v4",
+    indexUri: "file:///quickwit/qwdata/indexes-prod/woozi-events-v4",
+    commitTimeoutSecs: 60,
+  });
+  assertEquals(result.index_uri, "file:///quickwit/qwdata/indexes-prod/woozi-events-v4");
+  assertEquals((result.indexing_settings as Record<string, unknown>).commit_timeout_secs, 60);
+  assertEquals(result.doc_mapping, checkedIn.doc_mapping);
+  assertEquals(result.search_settings, checkedIn.search_settings);
+  // The input is not mutated: ensureIndex reads the file once per process.
+  assertEquals((checkedIn.indexing_settings as Record<string, unknown>).commit_timeout_secs, 1);
+});
+
+Deno.test("ingest commit mode defaults to wait_for and rejects nonsense", () => {
+  Deno.env.delete("QUICKWIT_INGEST_COMMIT");
+  assertEquals(getIngestCommitMode(), "wait_for");
+  Deno.env.set("QUICKWIT_INGEST_COMMIT", "");
+  assertEquals(getIngestCommitMode(), "wait_for");
+  Deno.env.set("QUICKWIT_INGEST_COMMIT", "auto");
+  assertEquals(getIngestCommitMode(), "auto");
+  Deno.env.set("QUICKWIT_INGEST_COMMIT", "yes please");
+  assertThrows(() => getIngestCommitMode(), Error, "QUICKWIT_INGEST_COMMIT");
+  Deno.env.delete("QUICKWIT_INGEST_COMMIT");
+});


### PR DESCRIPTION
Voorbereiding van de nieuwe index op lokale opslag: de code die nodig is om hem überhaupt goed aan te maken, plus het plan met de metingen van vandaag.

**Code.** `ensureIndex` stuurde `index-config.json` letterlijk door, dus elke nieuwe index erfde de S3-root van de node en `commit_timeout_secs: 1`. Precies de twee oorzaken uit het juli-document, en de migratie van 12 augustus kon niet anders. De worker leest nu `QUICKWIT_INDEX_URI` en `QUICKWIT_COMMIT_TIMEOUT_SECS` bij aanmaken en `QUICKWIT_INGEST_COMMIT` bij elke ingest; productie geeft ze door als `WORKER_*`, standaard leeg, dus voor een bestaande index verandert er niets. End-to-end geverifieerd tegen Quickwit 0.9.0.

**Metingen die het plan veranderen** (alles in `docs/local-index-plan.md`):

- **Geen 3,5× krimp.** v3b ís al een verse projectie; 86% van de 44,6M rijen zijn pagina's, primaire rijen zitten ~8% boven de 5,57M unieke entiteiten uit het export-log. Een v4 met dezelfde mapping wordt 57-60 GB. De echte krimp is Optie C (geen `content` per pagina opslaan) en dat is een productwijziging, geen onderdeel van deze operatie.
- **Niet op de root-schijf.** 101 GB vrij tegen 60 GB index plus merge-ruimte (grootste splits 12-18 GB) is het incident van 10 augustus opnieuw. Wél op het volume: daar staat de splitcache nu al op, dus elke warme zoekopdracht leest vandaag al van `/dev/sdb`. Een lokale index daar presteert als de warme cache van nu, zonder koude missers.
- **Quickwit 0.9.0** (uit sinds 25 juli) boot op onze config, en `PUT /api/v1/indexes/<id>` past `commit_timeout_secs` aan op een bestaande index. De churn op v3b kan dus op de dag van de upgrade al stoppen, vóór de reindex.
- **`wait_for` wacht de volle commit-timeout**: 60 s per batch bij 60, ook met vier parallel. `auto` keert in 20 ms terug. Vandaar de knop.
- **De splitcache wikkelt ook `file://`-opslag** en `max_num_bytes: 0` schakelt hem niet uit. Bij de cutover gaat de sectie uit `quickwit.yaml`.

**Volgorde** staat in het plan met per stap de controle die bepaalt of de volgende doorgaat: upgrade, churn stoppen, ruimte maken, v4 aanmaken via alleen de workers, één bron en dan alles, verifiëren, reader omzetten, en daarna het hele splitcache-blok verwijderen uit monitor, compose, node-config en collector.

Dev-compose neemt `QUICKWIT_IMAGE` zodat dit lokaal te herhalen is.
