### PR TITLE
Run Quickwit 0.9.0, the version that can change a commit timeout

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -425,6 +425,11 @@ reindex could never have finished at any speed or concurrency.
 It now points at `s3://${S3_STORAGE_BUCKET_NAME}/${QUICKWIT_INDEX_ROOT_PREFIX}`,
 matching where the live index already is. Two things to know:
 
+- **A Quickwit upgrade is one-way for the metastore.** 0.9.0 rewrites
+  `indexes-prod/manifest.json` and every `metastore.json` to format `0.9` at
+  startup; 0.8.1 refuses to start on them afterwards. Copy the whole
+  `indexes-prod` directory out of the volume before changing the tag, and
+  restore it to roll back.
 - **The deploy does not restart Quickwit.** `deploy-production.sh` brings up
   `openbesluitvorming worker caddy otel-collector` only, so a synced
   `quickwit.yaml` sits unread until Quickwit is restarted by hand. Restarting it

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -20,7 +20,11 @@ services:
       - caddy-config:/config
 
   quickwit:
-    image: quickwit/quickwit:0.8.1
+    # 0.9.0 rewrites the file metastore to its own format at startup and 0.8.1
+    # will not read that back. Rolling back means restoring the indexes-prod
+    # directory from the copy taken before the upgrade, not just the tag.
+    # See docs/local-index-plan.md, step 1.
+    image: quickwit/quickwit:0.9.0
     restart: unless-stopped
     command:
       - run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   # Does the search, needs an S3 bucket and a volume
   quickwit:
     # Override to try a newer Quickwit locally, e.g. QUICKWIT_IMAGE=quickwit/quickwit:0.9.0.
-    image: ${QUICKWIT_IMAGE:-quickwit/quickwit:0.8.1}
+    image: ${QUICKWIT_IMAGE:-quickwit/quickwit:0.9.0}
     command:
       - run
       - --config

--- a/docs/local-index-plan.md
+++ b/docs/local-index-plan.md
@@ -73,8 +73,14 @@ our `quickwit.yaml` and `index-config.json`:
 - `PUT /api/v1/indexes/<id>` updates `commit_timeout_secs` on an existing
   index. Verified: 60 to 90 on a live index. **This means the churn on v3b can
   be stopped the day of the upgrade, before any reindex.**
-- the file metastore is rewritten to format `0.9` on first write; back it up
-  first, there is no downgrade;
+- the file metastore is rewritten to format `0.9` **at startup**, not at
+  first write: rehearsed on a copy of the production `indexes-prod`
+  directory, the manifest and every metastore said `0.9` before any request
+  was made, with all 26 published splits and 44.6M documents intact. 0.8.1
+  then refuses to start on it (`unknown variant 0.9, expected 0.8`), so the
+  rollback is the copy of the whole `indexes-prod` directory, not one file;
+- 0.9 creates `otel-logs-v0_9` and `otel-traces-v0_9` for its own OTLP
+  endpoint on first start, next to the existing `v0_7` pair. Expected, harmless;
 - ingest V2 serves `/api/v1/<id>/ingest`. With `commit=wait_for` every batch
   waits the full `commit_timeout_secs`: measured 62s for one batch and 60s for
   four parallel batches at a timeout of 60. `commit=auto` returns in 20 ms.
@@ -101,9 +107,12 @@ worker through `WORKER_QUICKWIT_INDEX_URI`,
 Each step has a check that decides whether the next one happens.
 
 **0. Before touching anything.** `df` on both disks, the phantom check
-(tally against disk) at zero, and a copy of
-`/quickwit/qwdata/indexes-prod/woozi-events-v3b/metastore.json` outside the
-container. Note the current `/api/search` latency for comparison.
+(tally against disk) at zero, and a copy of the whole
+`/var/lib/docker/volumes/woozi_quickwit-data/_data/indexes-prod` directory
+(manifest plus every metastore, under 100 KB) outside the volume. Note the
+current `/api/search` latency for comparison. Done 2026-09-02 11:21 UTC:
+101 GB free on root, 79 GB on the volume, tally 65.2 GB against 65.2 GB on
+disk, 26 published splits, cold searches 5-10s and warm 45-80 ms.
 
 **1. Upgrade Quickwit to 0.9.0.** Change the image tag in
 `docker-compose.production.yml`, deploy, restart Quickwit by hand (the deploy


### PR DESCRIPTION
Stap 1 uit `docs/local-index-plan.md`. Alleen de image-tag; index, cache en monitor blijven zoals ze zijn.

**Waarom nu.** 0.9 heeft `PUT /api/v1/indexes/<id>`, en die past `commit_timeout_secs` aan op een bestaande index. Op 0.8 lag dat vast bij aanmaken, en v3b staat op 1 seconde. Op de dag dat dit landt kan v3b naar 60, en dan stopt de split-churn waar de hele cache-machinerie voor bestaat, vóór de reindex en los van wanneer die komt.

**Gerepeteerd op een kopie van de productie-`indexes-prod`-map**: 0.9.0 leest de 0.8-manifest en metastores, herschrijft ze bij het opstarten naar formaat 0.9 (niet pas bij de eerste write), houdt alle 26 gepubliceerde splits en 44,6M documenten, en beantwoordt de PUT met 60. 0.8.1 weigert daarna te starten op die bestanden (`unknown variant 0.9`), dus terugdraaien is de map terugzetten uit de kopie. Dat staat nu naast de tag in compose en in deployment.md. Bijvangst: 0.9 maakt bij de eerste start `otel-logs-v0_9` en `otel-traces-v0_9` aan naast de v0_7-paar; verwacht en onschadelijk.

**Uitvoering na merge** (de deploy synct compose maar herstart Quickwit niet):

1. kopie van `/var/lib/docker/volumes/woozi_quickwit-data/_data/indexes-prod` naar `/root/`
2. `docker compose -f docker-compose.production.yml up -d quickwit` — seconden geen zoeken
3. checks: `/api/v1/version` zegt 0.9.0, frasezoeken en datumsortering op v3b geven hetzelfde als de nulmeting, eerstvolgende import slaagt
4. `PUT` `commit_timeout_secs: 60` op v3b (stap 2 van het plan)

Nulmeting (stap 0) is gedaan om 11:21 UTC en staat in het plandocument.
