### PR TITLE
Reach Quickwit from the host, and read the metrics 0.9 actually publishes

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -430,10 +430,13 @@ matching where the live index already is. Two things to know:
   startup; 0.8.1 refuses to start on them afterwards. Copy the whole
   `indexes-prod` directory out of the volume before changing the tag, and
   restore it to roll back.
-- **The deploy does not restart Quickwit.** `deploy-production.sh` brings up
-  `openbesluitvorming worker caddy otel-collector` only, so a synced
-  `quickwit.yaml` sits unread until Quickwit is restarted by hand. Restarting it
-  makes search unavailable for a few seconds.
+- **The deploy restarts Quickwit only when its container definition changed.**
+  `deploy-production.sh` brings up `openbesluitvorming worker caddy
+  otel-collector`, but the web container `depends_on` Quickwit, so a changed
+  image tag or environment recreates it as part of that deploy (seen
+  2026-09-02 with the 0.9.0 tag). A synced `quickwit.yaml` is a mounted file
+  and does not count: it sits unread until Quickwit is restarted by hand.
+  Either way search is unavailable for a few seconds.
 - **Existing indexes keep the URI they were created with.** This changes nothing
   for `woozi-events-prod`; it only decides where the next index goes. Verify with
   `GET /api/v1/indexes/<id>` and look at `index_uri` before trusting a rebuild.

--- a/docs/local-index-plan.md
+++ b/docs/local-index-plan.md
@@ -121,11 +121,31 @@ does not). Search is unavailable for seconds. Check: `/api/v1/version` says
 returned before, the workers' next import succeeds. Rollback: the 0.8.1 tag
 plus the metastore copy from step 0.
 
+Done 2026-09-02 11:40 UTC. What it taught:
+
+- the deploy recreated Quickwit itself: the web container `depends_on` it,
+  and `docker compose up -d openbesluitvorming …` recreates a dependency
+  whose image changed. "The deploy does not restart Quickwit" holds for a
+  changed `quickwit.yaml` (a mounted file), not for a changed tag. Take the
+  metastore copy *before* merging the tag change, not after;
+- the 0.9 image has no `curl`, so every `docker exec … curl` in the monitor
+  became a silent no-op. It now reaches Quickwit from the host by container
+  IP;
+- 0.9 renamed the cache metrics: one family per measure with a
+  `component_name` label (`searcher_split`, `fd`, `fastfields`, …) instead
+  of a family per cache. The monitor and the collector filter follow;
+- `/api/search` takes `query`, not `q`, and an empty query without an
+  organization answers an empty list by design. A baseline taken with the
+  wrong parameter name looks exactly like an outage after the upgrade.
+
 **2. Stop the churn on v3b.** `PUT /api/v1/indexes/woozi-events-v3b` with
 `commit_timeout_secs: 60`. Check: the index config reports 60; over the next
 hour the number of published splits stops climbing between merges. This alone
 removes most of what the split cache machinery exists for, and it holds even
 if the reindex is postponed.
+
+Done 2026-09-02 11:57 UTC, after a one-week import of `maassluis` on 0.9
+succeeded end to end (run `5e885f68`, 3 meetings, row visible in v3b).
 
 **3. Make room on the volume.** Lower
 `QUICKWIT_SPLIT_CACHE_MAX_NUM_BYTES` to 40G for the duration and restart

--- a/otel/collector.yaml
+++ b/otel/collector.yaml
@@ -35,9 +35,18 @@ receivers:
           scrape_interval: 60s
           static_configs:
             - targets: ["quickwit:7280"]
+          # Quickwit 0.9 folded every cache into one metric family with a
+          # component_name label (0.8 had quickwit_cache_searcher_split_* and
+          # quickwit_cache_fd_*). Keep the two components that matter: the
+          # searcher split cache, whose in_cache_num_bytes is the tally the
+          # monitor compares against the disk, and the fd cache, whose count
+          # pinned at 100 was the descriptor leak of 2026-09-01.
           metric_relabel_configs:
             - source_labels: [__name__]
-              regex: "quickwit_cache_(searcher_split_.*|fd_in_cache_count)"
+              regex: "quickwit_cache_(in_cache_count|in_cache_num_bytes|cache_hits_bytes|cache_hits_total|cache_misses_total)"
+              action: keep
+            - source_labels: [component_name]
+              regex: "searcher_split|fd"
               action: keep
   hostmetrics:
     collection_interval: 60s

--- a/scripts/monitor-production.sh
+++ b/scripts/monitor-production.sh
@@ -566,6 +566,17 @@ check_worker_fds() {
   alert warning worker_fd_leak "Worker fd leak: restarted the import workers" "max_fds=${max_fds} threshold=${WORKER_FD_MAX}; interrupted runs are requeued by reconcile"
 }
 
+# Quickwit publishes no host port by design (compose network only), and the
+# 0.9 image ships without curl, so `docker exec woozi-quickwit-1 curl` -- which
+# is how this script reached it under 0.8 -- fails silently there. The host
+# can reach the container on the compose bridge, so ask Docker for its address
+# and talk to it directly. Empty when the container is not running.
+quickwit_base_url() {
+  local ip
+  ip="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' woozi-quickwit-1 2>/dev/null || true)"
+  [ -n "$ip" ] && printf 'http://%s:7280' "$ip"
+}
+
 quickwit_split_cache_heal_on_cooldown() {
   local state_file="$STATE_DIR/quickwit_split_cache_heal_last" now previous
   now="$(date +%s)"
@@ -608,9 +619,7 @@ quickwit_split_cache_full_restart() {
   find "$cache_src" -mindepth 1 -delete 2>/dev/null || true
   (cd /opt/woozi && docker compose -f docker-compose.production.yml up -d quickwit) >/dev/null 2>&1 || true
   for _ in $(seq 1 30); do
-    # Quickwit has no host-published port by design (compose network only),
-    # so the readiness probe has to run inside the container.
-    [ "$(docker exec woozi-quickwit-1 curl -s -o /dev/null -w '%{http_code}' -m 3 http://localhost:7280/health/readyz 2>/dev/null || true)" = "200" ] && break
+    [ "$(curl -s -o /dev/null -w '%{http_code}' -m 3 "$(quickwit_base_url)/health/readyz" 2>/dev/null || true)" = "200" ] && break
     sleep 2
   done
   # shellcheck disable=SC2086
@@ -647,9 +656,10 @@ check_quickwit_split_cache_pollution() {
 
   # What Quickwit thinks it holds, against what is actually there.
   local accounted_bytes disk_kb accounted_gb disk_gb phantom_gb
-  accounted_bytes="$(docker exec woozi-quickwit-1 sh -c \
-    "curl -s http://127.0.0.1:7280/metrics | grep '^quickwit_cache_searcher_split_in_cache_num_bytes ' | cut -d' ' -f2" \
-    2>/dev/null | xargs || true)"
+  # Quickwit 0.9 metric name; 0.8 called this
+  # quickwit_cache_searcher_split_in_cache_num_bytes without the label.
+  accounted_bytes="$(curl -s -m 5 "$(quickwit_base_url)/metrics" 2>/dev/null |
+    grep '^quickwit_cache_in_cache_num_bytes{component_name="searcher_split"} ' | cut -d' ' -f2 | xargs || true)"
   disk_kb="$(docker exec woozi-quickwit-1 sh -c "du -sk '${cache_dir}' 2>/dev/null | cut -f1" 2>/dev/null | xargs || true)"
   if [[ "${accounted_bytes:-}" =~ ^[0-9]+$ ]] && [[ "${disk_kb:-}" =~ ^[0-9]+$ ]]; then
     accounted_gb="$((accounted_bytes / 1000000000))"


### PR DESCRIPTION
Twee dingen die de 0.9-upgrade van vanmiddag stilletjes brak.

**Geen curl in de 0.9-image.** Het monitorscript bereikte Quickwit met `docker exec … curl`, voor de readiness-probe na een purge en voor de tally in de phantom-check. Beide falen nu binnen de container, en het script las het lege resultaat als niets te melden. De phantom-check was dus sinds 11:40 UTC een no-op. Quickwit publiceert bewust geen hostpoort, maar de host kan de container op de compose-bridge bereiken; het script vraagt Docker om het adres en praat er direct mee. Droog getest op productie: url gevonden, readyz 200, tally 65,2 GB gelezen, geen purge bij 20 GB, tak bereikt bij 1 GB.

**0.9 hernoemt de cache-metrics.** Eén familie per meting met een `component_name`-label in plaats van een familie per cache. Het keep-filter van #245 matchte dus niets meer op 0.9. Het filter houdt nu dezelfde twee componenten (`searcher_split`, `fd`) op label; config gevalideerd met de collector-image.

Ook in het plan opgeschreven: de deploy herstartte Quickwit zelf, via `depends_on` van de webcontainer. De metastore-kopie moet dus vóór het mergen van een tag-wijziging, niet erna. En deployment.md zei ten onrechte dat de deploy Quickwit nooit herstart.