### PR TITLE
Give the next index a home on the volume

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -91,6 +91,14 @@ services:
       # Worth revisiting if splits ever get smaller, or if the machine gets a
       # bigger root disk.
       - /mnt/quickwit-cache:/quickwit/qwdata/searcher-split-cache
+      # The next projection index lives on the same volume, as a local
+      # file:// index instead of an S3 index with a cache in front of it. The
+      # worker creates it there through WORKER_QUICKWIT_INDEX_URI; this mount
+      # is what makes that path land on /dev/sdb instead of the root disk
+      # (which cannot hold a 60 GB index plus merge headroom -- see
+      # docs/local-index-plan.md). Its metastore.json lands here too, because
+      # metastore_uri and the index root share the indexes-prod prefix.
+      - /mnt/quickwit-cache/indexes/woozi-events-v4:/quickwit/qwdata/indexes-prod/woozi-events-v4
       - ./quickwit/quickwit.yaml:/quickwit/config/quickwit.yaml:ro
 
   openbesluitvorming:


### PR DESCRIPTION
Stap 3 uit `docs/local-index-plan.md`: een bind mount voor de map van `woozi-events-v4` op het volume, naast de splitcache die hij gaat vervangen. Er schrijft niets naartoe tot een worker op v4 wordt gericht. De metastore van v4 landt in dezelfde map, want metastore-root en index-root delen het `indexes-prod`-voorvoegsel.

Bij dezelfde herstart gaat op de host het cachebudget naar 40G via `.env`, zodat v3b een warme werkset houdt terwijl v4 ernaast groeit. De deploy herstart Quickwit zelf omdat de containerdefinitie verandert.