### PR TITLE
Let a slow object delay only itself

### DIFF
--- a/src/pipeline/reindex.ts
+++ b/src/pipeline/reindex.ts
@@ -203,14 +203,21 @@ export async function reindexSource(
 
   let cursor: string | null = null;
   let pending: QuickwitSearchDocument[] = [];
+  // Flushes are serialised: rehydration finishes in whatever order object
+  // storage answers, and each completion may want to flush, but Quickwit is
+  // handed one batch at a time so the ingest side keeps its old shape.
+  let flushing: Promise<void> = Promise.resolve();
 
-  const flush = async (): Promise<void> => {
-    if (pending.length === 0) {
-      return;
-    }
-    const batch = pending;
-    pending = [];
-    await context.ingest(batch);
+  const flush = (): Promise<void> => {
+    flushing = flushing.then(async () => {
+      if (pending.length === 0) {
+        return;
+      }
+      const batch = pending;
+      pending = [];
+      await context.ingest(batch);
+    });
+    return flushing;
   };
 
   while (true) {
@@ -228,63 +235,59 @@ export async function reindexSource(
     // afterwards, so the batching and its memory behaviour are unchanged. The
     // slice is what bounds memory: a rehydrated document carries its page
     // chunks, so only `concurrency` of them are ever held beyond `pending`.
-    for (let offset = 0; offset < page.records.length; offset += concurrency) {
-      const slice = page.records.slice(offset, offset + concurrency);
-      const prepared = await mapLimit(slice, concurrency, async (record) => {
-        try {
-          const event = toCommitEvent(record);
-          const payload = event.data.payload;
-          let rehydrated = false;
+    // This used to walk the page in slices of `concurrency` records and wait
+    // for the whole slice before projecting any of it, which made every slice
+    // as slow as its slowest read. Measured 2026-09-03 against Hetzner: with a
+    // few reads per hundred taking 6-60s, 96 documents took 152s that way.
+    // Now every record of the page is in flight under the same limit and each
+    // one is projected the moment its own read completes; a slow object delays
+    // only itself. Memory is bounded the same way as before: at most
+    // `concurrency` rehydrated documents exist beyond `pending`, because a
+    // record is projected (and its text handed to `pending`) before the slot
+    // is reused.
+    await mapLimit(page.records, concurrency, async (record) => {
+      let event: EntityCommitEvent<WooziEntity>;
+      let isDocument = false;
+      let rehydrated = false;
+      try {
+        event = toCommitEvent(record);
+        const payload = event.data.payload;
+        isDocument = payload?.type === "Document";
 
-          if (payload?.type === "Document") {
-            rehydrated = await rehydrateDocumentText(payload, context.storage);
-          } else if (payload?.type === "Recording") {
-            rehydrated = await rehydrateTranscript(payload, context.storage);
-          }
-
-          return { record, event, isDocument: payload?.type === "Document", rehydrated };
-        } catch (error) {
-          return { record, error };
+        if (payload?.type === "Document") {
+          rehydrated = await rehydrateDocumentText(payload, context.storage);
+        } else if (payload?.type === "Recording") {
+          rehydrated = await rehydrateTranscript(payload, context.storage);
         }
-      });
-
-      for (const item of prepared) {
-        if ("error" in item && item.error) {
-          stats.issue_count += 1;
-          await context.onIssue?.({
-            severity: "warning",
-            step: "ingest_quickwit",
-            entity_id: item.record.entity_id,
-            message: `Reindex skipped ${item.record.entity_id}: ${
-              item.error instanceof Error ? item.error.message : String(item.error)
-            }`,
-          });
-          continue;
-        }
-
-        const { event, isDocument, rehydrated } = item as {
-          event: EntityCommitEvent<WooziEntity>;
-          isDocument: boolean;
-          rehydrated: boolean;
-        };
-
-        if (isDocument) {
-          stats.document_count += 1;
-        }
-        if (rehydrated) {
-          stats.rehydrated_count += 1;
-        }
-
-        pending.push(...projectEntityCommitToQuickwitDocuments(event));
-        stats.entity_count += 1;
-
-        // Documents carry their page chunks until the batch is flushed, so
-        // flush on the projected-document count rather than the entity count.
-        if (pending.length >= context.batchSize) {
-          await flush();
-        }
+      } catch (error) {
+        stats.issue_count += 1;
+        await context.onIssue?.({
+          severity: "warning",
+          step: "ingest_quickwit",
+          entity_id: record.entity_id,
+          message: `Reindex skipped ${record.entity_id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
+        return;
       }
-    }
+
+      if (isDocument) {
+        stats.document_count += 1;
+      }
+      if (rehydrated) {
+        stats.rehydrated_count += 1;
+      }
+
+      pending.push(...projectEntityCommitToQuickwitDocuments(event));
+      stats.entity_count += 1;
+
+      // Documents carry their page chunks until the batch is flushed, so
+      // flush on the projected-document count rather than the entity count.
+      if (pending.length >= context.batchSize) {
+        await flush();
+      }
+    });
 
     await context.onProgress?.(stats);
 

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -9,6 +9,15 @@
 // server-side closes correctly.
 
 import { AwsClient } from "npm:aws4fetch";
+
+/** Per-attempt ceiling on an object read; see getObjectBytes. */
+const READ_TIMEOUT_MS = Number(Deno.env.get("WOOZI_S3_READ_TIMEOUT_MS") ?? "15000");
+const READ_ATTEMPTS = 3;
+const READ_RETRY_BASE_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 import { getConfigValue } from "../config.ts";
 
 const DEFAULT_BUCKET = "woozi";
@@ -208,11 +217,11 @@ export class ObjectStorageClient {
         file.close();
       }
 
-      const completeXml = `<CompleteMultipartUpload>${
-        etags
-          .map((etag, index) => `<Part><PartNumber>${index + 1}</PartNumber><ETag>${etag}</ETag></Part>`)
-          .join("")
-      }</CompleteMultipartUpload>`;
+      const completeXml = `<CompleteMultipartUpload>${etags
+        .map(
+          (etag, index) => `<Part><PartNumber>${index + 1}</PartNumber><ETag>${etag}</ETag></Part>`,
+        )
+        .join("")}</CompleteMultipartUpload>`;
       const completeResponse = await this.client.fetch(
         `${url}?uploadId=${encodeURIComponent(uploadId)}`,
         { method: "POST", headers: { "content-type": "application/xml" }, body: completeXml },
@@ -220,7 +229,9 @@ export class ObjectStorageClient {
       const completeBody = await completeResponse.text();
       // S3 can return 200 with an <Error> body for a failed complete.
       if (!completeResponse.ok || completeBody.includes("<Error>")) {
-        throw new Error(`multipart complete failed: HTTP ${completeResponse.status} ${completeBody.slice(0, 200)}`);
+        throw new Error(
+          `multipart complete failed: HTTP ${completeResponse.status} ${completeBody.slice(0, 200)}`,
+        );
       }
     } catch (error) {
       if (uploadId) {
@@ -292,10 +303,9 @@ export class ObjectStorageClient {
 
     let body: string;
     try {
-      const response = await this.client.fetch(
-        `${this.endpoint}/${this.bucket}?${params}`,
-        { method: "GET" },
-      );
+      const response = await this.client.fetch(`${this.endpoint}/${this.bucket}?${params}`, {
+        method: "GET",
+      });
       if (!response.ok) {
         throw new Error(await errorSummary(response));
       }
@@ -305,7 +315,7 @@ export class ObjectStorageClient {
     }
 
     const keys = [...body.matchAll(/<Key>([^<]*)<\/Key>/g)].map((match) =>
-      decodeXmlEntities(match[1])
+      decodeXmlEntities(match[1]),
     );
     return {
       keys,
@@ -352,22 +362,61 @@ export class ObjectStorageClient {
     return deleted;
   }
 
+  /** Read one object, with a ceiling on how long a single attempt may take.
+   *
+   * Object storage answers most reads in tens of milliseconds and a few in
+   * tens of seconds: measured 2026-09-03 on Hetzner, 2-4% of GETs took 6-60s
+   * regardless of size, and some came back 504 after exactly 60s -- three
+   * times in a row through aws4fetch's own retry loop, which has no timeout.
+   * One such object then held a reindex slice for three minutes. So the
+   * attempts are made here, each under an abort signal, and aws4fetch is only
+   * asked to sign. Retried: a timeout, a network error, 429, and 5xx. Not
+   * retried: 404 (absent is an answer) and other 4xx. */
   async getObjectBytes(key: string): Promise<Uint8Array | null> {
-    let response: Response;
-    try {
-      response = await this.client.fetch(this.objectUrl(key), { method: "GET" });
-    } catch (error) {
-      throw describeStorageError("read", key, error);
-    }
+    const url = this.objectUrl(key);
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= READ_ATTEMPTS; attempt += 1) {
+      let response: Response;
+      try {
+        const signed = await this.client.sign(url, { method: "GET" });
+        response = await fetch(signed, { signal: AbortSignal.timeout(READ_TIMEOUT_MS) });
+      } catch (error) {
+        lastError = error;
+        if (attempt < READ_ATTEMPTS) {
+          await sleep(READ_RETRY_BASE_MS * attempt);
+          continue;
+        }
+        throw describeStorageError("read", key, error);
+      }
 
-    if (response.status === 404) {
-      await response.body?.cancel();
-      return null;
-    }
-    if (!response.ok) {
-      throw describeStorageError("read", key, new Error(await errorSummary(response)));
-    }
+      if (response.status === 404) {
+        await response.body?.cancel();
+        return null;
+      }
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new Error(await errorSummary(response));
+        if (attempt < READ_ATTEMPTS) {
+          await sleep(READ_RETRY_BASE_MS * attempt);
+          continue;
+        }
+        throw describeStorageError("read", key, lastError);
+      }
+      if (!response.ok) {
+        throw describeStorageError("read", key, new Error(await errorSummary(response)));
+      }
 
-    return new Uint8Array(await response.arrayBuffer());
+      try {
+        return new Uint8Array(await response.arrayBuffer());
+      } catch (error) {
+        // The body can stall after the headers arrived; the signal covers it.
+        lastError = error;
+        if (attempt < READ_ATTEMPTS) {
+          await sleep(READ_RETRY_BASE_MS * attempt);
+          continue;
+        }
+        throw describeStorageError("read", key, error);
+      }
+    }
+    throw describeStorageError("read", key, lastError);
   }
 }

--- a/tests/reindex.test.ts
+++ b/tests/reindex.test.ts
@@ -248,7 +248,7 @@ Deno.test("a recording without a stored transcript reindexes without failing", a
   assert(ingested[0].content?.includes("Opening"), "the chapters still make it searchable");
 });
 
-Deno.test("rehydration reads run in parallel, and the order still holds", async () => {
+Deno.test("rehydration reads run in parallel, and every record lands once", async () => {
   // The reindex is bounded by object-storage latency: one read per document,
   // 57% of live entities carrying stored text. Doing them one at a time held a
   // source to ~4 entities/second, which made Amsterdam alone a ~14 hour floor
@@ -290,10 +290,73 @@ Deno.test("rehydration reads run in parallel, and the order still holds", async 
     `and must respect the limit, peak was ${storage.peakConcurrency}`,
   );
 
-  // Parallel reads must not reshuffle what gets indexed.
-  const ids = ingested.map((doc) => doc.entity_id);
-  assertEquals([...ids].sort(), ids, `projection order must follow the export log: ${ids}`);
-  assert(ingested[0].content?.includes("inhoud van document 0"), "text arrives with its entity");
+  // Reads complete in whatever order storage answers; what matters is that
+  // every entity lands exactly once, with its own text.
+  const ids = ingested.map((doc) => doc.entity_id).sort();
+  assertEquals(
+    ids,
+    records.map((record) => record.entity_id).sort(),
+    `every record is projected once: ${ids}`,
+  );
+  const doc0 = ingested.find((doc) => doc.entity_id.endsWith(":d00"));
+  assert(doc0?.content?.includes("inhoud van document 0"), "text arrives with its entity");
+});
+
+Deno.test("one slow read delays only its own document", async () => {
+  // Measured 2026-09-03: object storage answered a few reads per hundred in
+  // 6-60s. The slice-at-a-time loop this replaces made every slice wait for
+  // its slowest read, so one such object held ~100 documents for minutes.
+  const records: ExportChangeRecord[] = [];
+  const objects: Record<string, string> = {};
+  for (let i = 0; i < 8; i += 1) {
+    const key = `text/doc-${i}/md.md`;
+    objects[key] = `tekst ${i}`;
+    records.push(documentRecord(`document:ibabs:gemeente:utrecht:d${i}`, { markdown: key }));
+  }
+  const storage = new FakeStorage(objects, 1);
+  const slowKey = "text/doc-3/md.md";
+  let releaseSlow: () => void = () => {};
+  const slowGate = new Promise<void>((resolve) => {
+    releaseSlow = resolve;
+  });
+  const originalGet = storage.getObjectText.bind(storage);
+  storage.getObjectText = async (key: string) => {
+    if (key === slowKey) {
+      await slowGate;
+    }
+    return originalGet(key);
+  };
+
+  const batches: string[][] = [];
+  const run = reindexSource("utrecht", {
+    // deno-lint-ignore no-explicit-any
+    exportLog: new FakeExportLog(records) as any,
+    // deno-lint-ignore no-explicit-any
+    storage: storage as any,
+    batchSize: 2,
+    rehydrateConcurrency: 4,
+    ingest: (documents) => {
+      batches.push(documents.map((doc) => doc.entity_id));
+      return Promise.resolve();
+    },
+  });
+
+  // Give the fast reads time to finish while doc-3 is still held.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const landedBeforeRelease = batches.flat().length;
+  assert(
+    landedBeforeRelease >= 6,
+    `documents behind the slow one must not wait for it, got ${landedBeforeRelease}`,
+  );
+  assert(
+    !batches.flat().includes("document:ibabs:gemeente:utrecht:d3"),
+    "the slow one is not in yet",
+  );
+
+  releaseSlow();
+  const stats = await run;
+  assertEquals(stats.entity_count, 8, "and everything lands in the end");
+  assert(batches.flat().includes("document:ibabs:gemeente:utrecht:d3"), "including the slow one");
 });
 
 Deno.test("a failing rehydration is reported per record, not per slice", async () => {

--- a/tests/s3_read_resilience.test.ts
+++ b/tests/s3_read_resilience.test.ts
@@ -1,0 +1,68 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert";
+
+// The read timeout is read once at module load, so set it before importing.
+Deno.env.set("WOOZI_S3_READ_TIMEOUT_MS", "80");
+Deno.env.set("S3_STORAGE_BUCKET_NAME", "test-bucket");
+Deno.env.set("S3_STORAGE_ENDPOINT", "https://storage.test");
+Deno.env.set("S3_STORAGE_REGION", "test-1");
+Deno.env.set("S3_ACCESS_KEY", "key");
+Deno.env.set("S3_SECRET_KEY", "secret");
+const { ObjectStorageClient } = await import("../src/storage/s3.ts");
+
+type FetchFn = typeof globalThis.fetch;
+
+async function withFetch<T>(stub: FetchFn, body: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = stub;
+  try {
+    return await body();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+Deno.test("a read that hangs is abandoned at the timeout and retried", async () => {
+  // Measured 2026-09-03: a few reads per hundred took 6-60s, and the same
+  // key would then answer promptly on the next attempt.
+  let calls = 0;
+  const stub: FetchFn = (_input, init) => {
+    calls += 1;
+    if (calls < 3) {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      });
+    }
+    return Promise.resolve(new Response("inhoud", { status: 200 }));
+  };
+  const storage = await ObjectStorageClient.fromEnvironment();
+  const text = await withFetch(stub, () => storage.getObjectText("text/doc.md"));
+  assertEquals(text, "inhoud");
+  assertEquals(calls, 3);
+});
+
+Deno.test("a gateway timeout is retried, and given up after three attempts", async () => {
+  let calls = 0;
+  const stub: FetchFn = () => {
+    calls += 1;
+    return Promise.resolve(new Response("upstream timed out", { status: 504 }));
+  };
+  const storage = await ObjectStorageClient.fromEnvironment();
+  await assertRejects(
+    () => withFetch(stub, () => storage.getObjectBytes("text/doc.md")),
+    Error,
+    "504",
+  );
+  assertEquals(calls, 3);
+});
+
+Deno.test("absent is an answer: 404 is returned at once, not retried", async () => {
+  let calls = 0;
+  const stub: FetchFn = () => {
+    calls += 1;
+    return Promise.resolve(new Response("", { status: 404 }));
+  };
+  const storage = await ObjectStorageClient.fromEnvironment();
+  const bytes = await withFetch(stub, () => storage.getObjectBytes("text/missing.md"));
+  assertEquals(bytes, null);
+  assertEquals(calls, 1);
+});


### PR DESCRIPTION
Twee wijzigingen aan het reindex-pad, uit een nacht kijken naar de v4-campagne (#248) die vastliep op Hetzner object storage.

**Object-reads hadden geen plafond.** aws4fetch retryt een 5xx drie keer zonder eigen timeout, en Hetzner beantwoordde vannacht 2-4% van de reads in 6-60 s, sommige met een 504 na precies 60 s, ongeacht objectgrootte. Eén sleutel kon zo drie minuten vasthouden. De storage-client doet nu zelf de pogingen, elk onder een abort-signaal (15 s, `WOOZI_S3_READ_TIMEOUT_MS`), en laat aws4fetch alleen signeren. Timeout, netwerkfout, 429 en 5xx worden drie keer geprobeerd; 404 komt direct terug.

**De reindex wachtte per plak.** `reindexSource` rehydrateerde `concurrency` records tegelijk en projecteerde er geen tot de traagste read klaar was, dus één traag object hield de hele plak vast: gemeten 96 documenten in 152 s. Nu is elke record van een pagina onder dezelfde limiet in de lucht en wordt hij geprojecteerd zodra zijn eigen read klaar is. Flushes zijn geserialiseerd, dus Quickwit krijgt nog steeds één batch tegelijk; de geheugengrens is gelijk. Projectievolgorde binnen een pagina volgt nu de voltooiingsvolgorde, waar niets van afhing.

Tests: timeout-dan-retry, 504 geeft na drie pogingen op, 404 wordt niet geretryd, en een vastgehouden read blokkeert de documenten erachter niet.

**Effect op de lopende campagne**: mergen deployt en maakt de workers opnieuw aan; lopende runs beginnen opnieuw (zoals bij elke herstart vannacht), daarna zonder plak-wachttijden.