### PR TITLE
Back off when object storage says slow down

### DIFF
--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -12,8 +12,25 @@ import { AwsClient } from "npm:aws4fetch";
 
 /** Per-attempt ceiling on an object read; see getObjectBytes. */
 const READ_TIMEOUT_MS = Number(Deno.env.get("WOOZI_S3_READ_TIMEOUT_MS") ?? "15000");
-const READ_ATTEMPTS = 3;
-const READ_RETRY_BASE_MS = 500;
+/** Attempts per read, with exponential back-off between them: 1s, 2s, 4s,
+ * 8s, 16s -- about half a minute in total before a read is given up. Object
+ * storage answers a burst it dislikes with `503 SlowDown: Please reduce your
+ * request rate`; measured 2026-09-03 during the v4 reindex, 24,800 reads in a
+ * few hours were refused that way and skipped, because three attempts half a
+ * second apart are three chances to hit the same throttle. A throttle wants
+ * patience, not persistence. `Retry-After`, when the server sends one, wins. */
+const READ_ATTEMPTS = 6;
+const READ_RETRY_BASE_MS = 1_000;
+const READ_RETRY_MAX_MS = 16_000;
+
+function readRetryDelayMs(attempt: number, retryAfter: string | null): number {
+  const advised = retryAfter ? Number(retryAfter) : NaN;
+  if (Number.isFinite(advised) && advised > 0) {
+    return Math.min(advised * 1000, 60_000);
+  }
+  const exponential = Math.min(READ_RETRY_MAX_MS, READ_RETRY_BASE_MS * 2 ** (attempt - 1));
+  return exponential + Math.floor(Math.random() * 250);
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -383,7 +400,7 @@ export class ObjectStorageClient {
       } catch (error) {
         lastError = error;
         if (attempt < READ_ATTEMPTS) {
-          await sleep(READ_RETRY_BASE_MS * attempt);
+          await sleep(readRetryDelayMs(attempt, null));
           continue;
         }
         throw describeStorageError("read", key, error);
@@ -394,9 +411,10 @@ export class ObjectStorageClient {
         return null;
       }
       if (response.status === 429 || response.status >= 500) {
+        const retryAfter = response.headers.get("retry-after");
         lastError = new Error(await errorSummary(response));
         if (attempt < READ_ATTEMPTS) {
-          await sleep(READ_RETRY_BASE_MS * attempt);
+          await sleep(readRetryDelayMs(attempt, retryAfter));
           continue;
         }
         throw describeStorageError("read", key, lastError);
@@ -411,7 +429,7 @@ export class ObjectStorageClient {
         // The body can stall after the headers arrived; the signal covers it.
         lastError = error;
         if (attempt < READ_ATTEMPTS) {
-          await sleep(READ_RETRY_BASE_MS * attempt);
+          await sleep(readRetryDelayMs(attempt, null));
           continue;
         }
         throw describeStorageError("read", key, error);

--- a/tests/s3_read_resilience.test.ts
+++ b/tests/s3_read_resilience.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert";
+import { assert, assertEquals, assertRejects } from "jsr:@std/assert";
 
 // The read timeout is read once at module load, so set it before importing.
 Deno.env.set("WOOZI_S3_READ_TIMEOUT_MS", "80");
@@ -40,18 +40,48 @@ Deno.test("a read that hangs is abandoned at the timeout and retried", async () 
   assertEquals(calls, 3);
 });
 
-Deno.test("a gateway timeout is retried, and given up after three attempts", async () => {
+Deno.test("a throttled read backs off and is given up after six attempts", async () => {
+  // Object storage says `503 SlowDown` to a burst; the answer is to wait,
+  // and to obey Retry-After when it is given. The stub advises a tiny wait so
+  // the test stays fast while proving the header is honoured.
   let calls = 0;
+  const started = performance.now();
   const stub: FetchFn = () => {
     calls += 1;
-    return Promise.resolve(new Response("upstream timed out", { status: 504 }));
+    return Promise.resolve(
+      new Response("SlowDown: Please reduce your request rate", {
+        status: 503,
+        headers: { "retry-after": "0.01" },
+      }),
+    );
   };
   const storage = await ObjectStorageClient.fromEnvironment();
   await assertRejects(
     () => withFetch(stub, () => storage.getObjectBytes("text/doc.md")),
     Error,
-    "504",
+    "503",
   );
+  assertEquals(calls, 6);
+  assert(
+    performance.now() - started < 2000,
+    "Retry-After of 10ms must not be ignored for a 1s back-off",
+  );
+});
+
+Deno.test("a throttled read that recovers returns the object", async () => {
+  let calls = 0;
+  const stub: FetchFn = () => {
+    calls += 1;
+    if (calls < 3) {
+      return Promise.resolve(
+        new Response("SlowDown", { status: 503, headers: { "retry-after": "0.01" } }),
+      );
+    }
+    return Promise.resolve(new Response("inhoud", { status: 200 }));
+  };
+  const storage = await ObjectStorageClient.fromEnvironment();
+  const text = await withFetch(stub, () => storage.getObjectText("text/doc.md"));
+  assertEquals(text, "inhoud");
   assertEquals(calls, 3);
 });
 


### PR DESCRIPTION
De read-retry van vanochtend deed drie pogingen met een halve seconde ertussen. Tegen een throttle zijn dat drie kansen om dezelfde muur te raken: Hetzner beantwoordde tijdens de v4-reindex 24.800 reads met `503 SlowDown: Please reduce your request rate` en 4.800 met een timeout, en elk daarvan werd een overgeslagen document (29.650 in totaal, staan in `/root/v4-skipped-entities.txt` op de host en worden na de campagne opnieuw geprojecteerd).

Reads doen nu zes pogingen met exponentiële back-off, 1 s verdubbelend tot 16 s, samen ongeveer een halve minuut, en volgen `Retry-After` als de server die meegeeft. De concurrency van de reindex zelf is de andere helft van het antwoord en zit in de campagne-instellingen (`WOOZI_REINDEX_CONCURRENCY` terug van 64 naar 8).

Tests: throttle die herstelt geeft het object terug; throttle die aanhoudt geeft na zes pogingen op en respecteert een korte Retry-After.