### PR TITLE
Registers are documents too, and coverage is measured

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,12 @@ Current implemented slices:
   `docs_internal/bsn-takedown.md` ("Stap 6") for the per-supplier
   "genuinely gone" calibration and the org-wide-outage-vs-real-deletion
   distinction.
+- A weekly coverage check (`scripts/coverage_check.ts`, `woozi-coverage.timer`)
+  compares the document ids each supplier's API lists for the last 12 months
+  with the export log and stores the result in `coverage_check`; `/api/status`
+  exposes it as `coverage` per source. "Last import succeeded" only says the
+  run finished; `coverage` says whether it asked for everything (#258 found
+  a Notubiz source at 11% for 2025 while its status was green).
 - The admin dashboard polls every 5s. Any per-run work it does (e.g. fetching run detail) multiplies by the number of visible runs — keep the dashboard cheap so it doesn't starve the single-threaded `openbesluitvorming` process and slow down user searches.
 
 ### iBabs specifics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@ Current implemented slices:
 
 - Notubiz, iBabs (165 sources, date-range chunked), GemeenteOplossingen, and
   Parlaeus meetings and documents (production)
+- registers: every Notubiz module and every iBabs list that is not a motion
+  list (ingekomen stukken, raadsvoorstellen, schriftelijke vragen,
+  toezeggingen, ...). Their attachments are Documents classified by the
+  register's name; the entry itself is not an entity. Since 2025 Notubiz
+  organisations publish most new material this way (#258); the Notubiz
+  window is the module item's date, the iBabs window its MutationDate, and
+  `WOOZI_IBABS_REGISTER_LIMIT` (default 2000) caps entries per run.
 - document download and caching
 - markdown extraction with `transmutation` + remote extraction workers
 - PDF page-chunk derivation

--- a/API.md
+++ b/API.md
@@ -388,6 +388,7 @@ at all — i.e. how long the outage has lasted.
 | `lastErrorMessage` | Why the last run failed. Present only when it did. Query strings are stripped |
 | `latestContentDate` | Newest meeting date held for this organization. Often in the future — an agenda is published before the meeting happens |
 | `lastIndexedAt` | When anything was last written to the search index for this organization |
+| `coverage` | Present once the weekly coverage check has covered this organization. What the source system's own API listed for a date window, against what the index holds: `supplierDocuments`, `heldDocuments`, `missingDocuments` (the first two partition the third), `ratio` (held over supplier; 1 means complete), `windowFrom`/`windowTo`, `checkedAt`, `missingSample` (a few missing document ids), `lowerBound` (true when some supplier requests failed, so the gap may be larger), and `error` when the check itself failed. `state: "ok"` says the last import ran; `coverage` says whether it asked for everything |
 | `discontinuedAt` | The date the organization ceased to exist. Only on `discontinued` |
 | `succeededBy` | `{ cbsId, label, sourceKey }` of the organization that took over. `sourceKey` is absent when we do not import the successor. Only on `discontinued` |
 

--- a/deployment.md
+++ b/deployment.md
@@ -835,6 +835,18 @@ Three systemd timers run on the production host:
   [docs_internal/bsn-takedown.md](docs_internal/bsn-takedown.md) for the
   calibration details and the ori3 equivalent. Install with
   [scripts/install-production-revalidate.sh](scripts/install-production-revalidate.sh).
+- **Coverage check** (`woozi-coverage.timer`, weekly, Sunday 05:00): for every
+  runnable source, `scripts/coverage_check.ts` lists the document ids the
+  supplier's own API exposes for the last 12 months -- meeting documents and
+  register/motion attachments -- and compares them with the export log. The
+  result goes to `coverage_check` in the ops SQLite and appears in
+  `/api/status` as `coverage` per source (supplier count, held, missing, a
+  sample of missing ids). Nothing is downloaded. It shares the suppliers'
+  request budgets with the nightly import, so it runs one source at a time on
+  a quiet morning; a full pass takes a few hours. Run one source by hand with
+  `docker exec woozi-openbesluitvorming-1 deno run -A scripts/coverage_check.ts
+  --source ermelo --dry-run`. Install with
+  [scripts/install-production-coverage.sh](scripts/install-production-coverage.sh).
 
 To restore: download the newest `backups/sqlite/...` object, gunzip, stop the
 `openbesluitvorming` and `worker` containers, replace the file on the

--- a/scripts/coverage_check.ts
+++ b/scripts/coverage_check.ts
@@ -1,0 +1,137 @@
+/**
+ * Coverage check: compare what each supplier lists against what we hold.
+ *
+ * For every runnable source (or one, with --source), list the document ids
+ * the supplier's API exposes for the window and compare them with the
+ * document ids in the export log. The result lands in the ops store
+ * (`coverage_check`) and from there in `/api/status` as `coverage` per
+ * source. Nothing is downloaded and nothing is imported.
+ *
+ * Usage:
+ *   deno run -A scripts/coverage_check.ts                    # every source, last 12 months
+ *   deno run -A scripts/coverage_check.ts --months 6
+ *   deno run -A scripts/coverage_check.ts --source ermelo
+ *   deno run -A scripts/coverage_check.ts --supplier notubiz
+ *   deno run -A scripts/coverage_check.ts --dry-run          # print, do not record
+ *
+ * Runs weekly on production from a systemd timer
+ * (scripts/install-production-coverage.sh). It shares the suppliers' request
+ * budgets with the nightly import -- iBabs is paced by the same fleet-wide
+ * limiter -- which is why it runs on a quiet morning and one source at a
+ * time.
+ */
+import { parseArgs } from "node:util";
+import { compareCoverage, listSupplierDocuments } from "../src/coverage/check.ts";
+import { getExportLog } from "../src/exports/log.ts";
+import { recordCoverageCheck } from "../src/ops/store.ts";
+import { listRunnableCatalogSources, listSources } from "../src/sources/index.ts";
+
+const args = parseArgs({
+  args: Deno.args,
+  options: {
+    source: { type: "string" },
+    supplier: { type: "string" },
+    months: { type: "string", default: "12" },
+    "dry-run": { type: "boolean", default: false },
+  },
+}).values;
+
+const months = Number(args.months);
+if (!Number.isInteger(months) || months <= 0) {
+  console.error(`--months must be a positive integer, got ${JSON.stringify(args.months)}`);
+  Deno.exit(1);
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+const now = new Date();
+const from = new Date(now);
+from.setUTCMonth(from.getUTCMonth() - months);
+const windowFrom = isoDate(from);
+const windowTo = isoDate(now);
+
+const runnable = new Set(listRunnableCatalogSources().map((entry) => entry.key));
+const sources = listSources().filter(
+  (source) =>
+    runnable.has(source.key) &&
+    (!args.source || source.key === args.source) &&
+    (!args.supplier || source.supplier === args.supplier),
+);
+if (sources.length === 0) {
+  console.error("No sources match.");
+  Deno.exit(1);
+}
+
+const exportLog = await getExportLog();
+console.log(
+  `coverage check: ${sources.length} source(s), window ${windowFrom}..${windowTo}${
+    args["dry-run"] ? " [dry-run]" : ""
+  }`,
+);
+
+let checked = 0;
+let failed = 0;
+for (const source of sources) {
+  const started = performance.now();
+  const checkedAt = new Date().toISOString();
+  try {
+    const listing = await listSupplierDocuments(source, windowFrom, windowTo);
+    const held = exportLog.listEntityIds(source.key, "document:");
+    const comparison = compareCoverage(listing.documentIds, held);
+    const ratio =
+      comparison.supplierDocuments > 0
+        ? comparison.heldDocuments / comparison.supplierDocuments
+        : 1;
+    console.log(
+      `${source.key.padEnd(26)} supplier=${String(comparison.supplierDocuments).padStart(6)} ` +
+        `held=${String(comparison.heldDocuments).padStart(6)} missing=${String(
+          comparison.missingDocuments,
+        ).padStart(6)} ` +
+        `(${(ratio * 100).toFixed(1)}%) meetings=${listing.meetings} entries=${listing.registerEntries}` +
+        `${listing.warnings.length > 0 ? ` warnings=${listing.warnings.length}` : ""} ` +
+        `${Math.round((performance.now() - started) / 1000)}s`,
+    );
+    for (const warning of listing.warnings.slice(0, 3)) {
+      console.log(`  warning: ${warning}`);
+    }
+    if (!args["dry-run"]) {
+      await recordCoverageCheck({
+        source_key: source.key,
+        checked_at: checkedAt,
+        window_from: windowFrom,
+        window_to: windowTo,
+        supplier_documents: comparison.supplierDocuments,
+        held_documents: comparison.heldDocuments,
+        missing_documents: comparison.missingDocuments,
+        missing_sample: comparison.missingSample,
+        supplier_meetings: listing.meetings,
+        register_entries: listing.registerEntries,
+        warnings: listing.warnings.length,
+      });
+    }
+    checked += 1;
+  } catch (error) {
+    failed += 1;
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`${source.key.padEnd(26)} FAILED: ${message.slice(0, 200)}`);
+    if (!args["dry-run"]) {
+      await recordCoverageCheck({
+        source_key: source.key,
+        checked_at: checkedAt,
+        window_from: windowFrom,
+        window_to: windowTo,
+        supplier_documents: 0,
+        held_documents: 0,
+        missing_documents: 0,
+        missing_sample: [],
+        supplier_meetings: 0,
+        register_entries: 0,
+        warnings: 0,
+        error: message.slice(0, 500),
+      });
+    }
+  }
+}
+console.log(`done: ${checked} checked, ${failed} failed`);

--- a/scripts/install-production-coverage.sh
+++ b/scripts/install-production-coverage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install the weekly coverage check on the production host: a systemd timer
+# that runs scripts/coverage_check.ts inside the web container and stores the
+# result in the ops database, where /api/status reads it.
+#
+# Usage: DEPLOY_HOST=root@host WOOZI_COVERAGE_DAY=Sun WOOZI_COVERAGE_TIME=05:00 \
+#        bash scripts/install-production-coverage.sh
+set -euo pipefail
+
+DEPLOY_HOST="${DEPLOY_HOST:-root@91.98.32.151}"
+COVERAGE_DAY="${WOOZI_COVERAGE_DAY:-Sun}"
+COVERAGE_TIME="${WOOZI_COVERAGE_TIME:-05:00}"
+COVERAGE_MONTHS="${WOOZI_COVERAGE_MONTHS:-12}"
+
+ssh "$DEPLOY_HOST" "COVERAGE_DAY='$COVERAGE_DAY' COVERAGE_TIME='$COVERAGE_TIME' COVERAGE_MONTHS='$COVERAGE_MONTHS' bash -s" <<'REMOTE'
+set -euo pipefail
+
+cat > /etc/systemd/system/woozi-coverage.service <<EOF
+[Unit]
+Description=OpenBesluitvorming coverage check: supplier listing against export log
+Wants=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+# Sources one at a time, sharing the suppliers' request budgets with the
+# nightly import; a full pass over ~330 sources takes a few hours.
+ExecStart=/usr/bin/docker exec woozi-openbesluitvorming-1 deno run -A scripts/coverage_check.ts --months ${COVERAGE_MONTHS}
+EOF
+
+cat > /etc/systemd/system/woozi-coverage.timer <<EOF
+[Unit]
+Description=Weekly OpenBesluitvorming coverage check
+
+[Timer]
+OnCalendar=${COVERAGE_DAY} *-*-* ${COVERAGE_TIME}:00
+RandomizedDelaySec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now woozi-coverage.timer
+systemctl list-timers woozi-coverage.timer --no-pager
+REMOTE
+
+echo "Installed woozi-coverage.timer (${COVERAGE_DAY} ${COVERAGE_TIME}, ${COVERAGE_MONTHS} months) on $DEPLOY_HOST"

--- a/src/coverage/check.ts
+++ b/src/coverage/check.ts
@@ -1,0 +1,365 @@
+/**
+ * Coverage check: does the search index hold what the supplier publishes?
+ *
+ * For one source and one date window, list every document id the supplier's
+ * own API exposes -- meeting documents, and the attachments of register and
+ * motion entries -- and compare that set with the document ids the export log
+ * holds for the source. What the supplier lists and we lack is the gap; it is
+ * counted and sampled, and the result is stored so `/api/status` can show it
+ * next to "last import succeeded".
+ *
+ * The comparison is by canonical document id, the same id the importers
+ * build, so a supplier count here means exactly what an import would have
+ * produced. It reuses the clients and the pure normalisers and downloads
+ * nothing.
+ *
+ * This is the application control asked for in #258: until now the status
+ * page could only say that the last import ran without errors, which is true
+ * of a run that structurally never asks for half the documents (#226, #258).
+ */
+import { GemeenteOplossingenClient } from "../gemeenteoplossingen/client.ts";
+import { normalizeGoDocuments, normalizeGoMeeting } from "../gemeenteoplossingen/normalize.ts";
+import { IbabsClient } from "../ibabs/client.ts";
+import {
+  normalizeIbabsDocuments,
+  normalizeIbabsMeeting,
+  normalizeIbabsMotion,
+  normalizeIbabsMotionDocuments,
+  normalizeIbabsRegisterDocuments,
+} from "../ibabs/normalize.ts";
+import { NotubizClient } from "../notubiz/client.ts";
+import {
+  isMotionModule,
+  isRegisterModule,
+  normalizeNotubizMotion,
+  normalizeNotubizMotionDocuments,
+  normalizeNotubizRegisterDocuments,
+} from "../notubiz/motions.ts";
+import { normalizeNotubizDocuments, normalizeNotubizMeeting } from "../notubiz/normalize.ts";
+import { ParlaeusClient } from "../parlaeus/client.ts";
+import { normalizeParlaeusAgenda } from "../parlaeus/normalize.ts";
+import type {
+  GemeenteOplossingenSourceDefinition,
+  IbabsSourceDefinition,
+  NotubizModuleItem,
+  NotubizSourceDefinition,
+  ParlaeusSourceDefinition,
+  SourceDefinition,
+} from "../types.ts";
+import { mapLimit } from "../util/map_limit.ts";
+
+export interface SupplierDocumentListing {
+  /** Canonical document ids the supplier exposes in the window. */
+  documentIds: Set<string>;
+  meetings: number;
+  /** Register/motion entries whose attachments were listed. */
+  registerEntries: number;
+  /** Requests that failed; the listing is then a lower bound. */
+  warnings: string[];
+}
+
+export interface CoverageComparison {
+  supplierDocuments: number;
+  heldDocuments: number;
+  /** Supplier documents absent from the export log. */
+  missingDocuments: number;
+  /** Up to `sampleSize` missing ids, for a human to look at. */
+  missingSample: string[];
+}
+
+/** The pure part: what the supplier lists minus what we hold. Held documents
+ * outside the supplier's listing (older, or from a register the supplier no
+ * longer shows) are not a gap and are not counted against anyone. */
+export function compareCoverage(
+  supplierIds: Iterable<string>,
+  heldIds: Iterable<string>,
+  sampleSize = 25,
+): CoverageComparison {
+  const held = heldIds instanceof Set ? heldIds : new Set(heldIds);
+  const supplier = supplierIds instanceof Set ? supplierIds : new Set(supplierIds);
+  const missing: string[] = [];
+  let heldInWindow = 0;
+  for (const id of supplier) {
+    if (held.has(id)) {
+      heldInWindow += 1;
+    } else {
+      missing.push(id);
+    }
+  }
+  missing.sort();
+  return {
+    supplierDocuments: supplier.size,
+    heldDocuments: heldInWindow,
+    missingDocuments: missing.length,
+    missingSample: missing.slice(0, sampleSize),
+  };
+}
+
+const NOTUBIZ_MEETING_CONCURRENCY = 4;
+
+async function listNotubiz(
+  source: NotubizSourceDefinition,
+  dateFrom: string,
+  dateTo: string,
+  client = new NotubizClient(),
+): Promise<SupplierDocumentListing> {
+  const listing: SupplierDocumentListing = {
+    documentIds: new Set(),
+    meetings: 0,
+    registerEntries: 0,
+    warnings: [],
+  };
+  const attributes = await client.getOrganizationAttributes(source.notubizOrganizationId);
+
+  const meetingIds: number[] = [];
+  for (let page = 1; ; page += 1) {
+    const response = (await client.listEvents(
+      source.notubizOrganizationId,
+      dateFrom,
+      dateTo,
+      page,
+    )) as { events?: unknown[]; pagination?: { has_more_pages?: boolean } };
+    const events = Array.isArray(response.events) ? response.events : [];
+    if (events.length === 0) {
+      break;
+    }
+    for (const event of events) {
+      const record = event as { id?: unknown; permission_group?: unknown };
+      if (record.permission_group === "public" && typeof record.id === "number") {
+        meetingIds.push(record.id);
+      }
+    }
+    if (!response.pagination?.has_more_pages) {
+      break;
+    }
+  }
+
+  await mapLimit(meetingIds, NOTUBIZ_MEETING_CONCURRENCY, async (meetingId) => {
+    try {
+      const response = (await client.getMeeting(meetingId)) as { meeting?: unknown };
+      if (!response.meeting) {
+        listing.warnings.push(`meeting ${meetingId}: no detail`);
+        return;
+      }
+      const meeting = normalizeNotubizMeeting(source, attributes, response.meeting);
+      listing.meetings += 1;
+      for (const document of normalizeNotubizDocuments(source, meeting)) {
+        listing.documentIds.add(document.id);
+      }
+    } catch (error) {
+      listing.warnings.push(`meeting ${meetingId}: ${errorText(error)}`);
+    }
+  });
+
+  let modules;
+  try {
+    modules = await client.listModules(source.notubizOrganizationId);
+  } catch (error) {
+    listing.warnings.push(`modules: ${errorText(error)}`);
+    return listing;
+  }
+  for (const module of modules) {
+    if (!isMotionModule(module) && !isRegisterModule(module)) {
+      continue;
+    }
+    let items: NotubizModuleItem[];
+    try {
+      items = await client.listModuleItems(
+        source.notubizOrganizationId,
+        module.id,
+        dateFrom,
+        dateTo,
+      );
+    } catch (error) {
+      listing.warnings.push(`module ${module.name}: ${errorText(error)}`);
+      continue;
+    }
+    for (const item of items) {
+      if (item.permission_group && item.permission_group !== "public") {
+        continue;
+      }
+      listing.registerEntries += 1;
+      const documents = isMotionModule(module)
+        ? normalizeNotubizMotionDocuments(
+            source,
+            normalizeNotubizMotion(source, module, item),
+            item,
+          )
+        : normalizeNotubizRegisterDocuments(source, module, item);
+      for (const document of documents) {
+        listing.documentIds.add(document.id);
+      }
+    }
+  }
+  return listing;
+}
+
+const IBABS_ENTRY_CONCURRENCY = 2;
+
+async function listIbabs(
+  source: IbabsSourceDefinition,
+  dateFrom: string,
+  dateTo: string,
+  client = new IbabsClient(),
+): Promise<SupplierDocumentListing> {
+  const listing: SupplierDocumentListing = {
+    documentIds: new Set(),
+    meetings: 0,
+    registerEntries: 0,
+    warnings: [],
+  };
+  const meetingTypes = new Map<string, string>();
+  try {
+    for (const meetingType of await client.getMeetingTypes(source)) {
+      meetingTypes.set(
+        meetingType.Id,
+        meetingType.Description ?? meetingType.Meetingtype ?? meetingType.Id,
+      );
+    }
+  } catch (error) {
+    listing.warnings.push(`meeting types: ${errorText(error)}`);
+  }
+
+  for (const rawMeeting of await client.listMeetingsByDateRange(source, dateFrom, dateTo)) {
+    try {
+      const meeting = normalizeIbabsMeeting(source, rawMeeting, meetingTypes);
+      listing.meetings += 1;
+      for (const document of normalizeIbabsDocuments(source, meeting)) {
+        listing.documentIds.add(document.id);
+      }
+    } catch (error) {
+      listing.warnings.push(`meeting: ${errorText(error)}`);
+    }
+  }
+
+  let lists;
+  try {
+    lists = await client.getLists(source);
+  } catch (error) {
+    listing.warnings.push(`lists: ${errorText(error)}`);
+    return listing;
+  }
+  const motionPattern = /moties?|amendement|stemming/i;
+  for (const list of lists) {
+    if (!list.ListName?.trim()) {
+      continue;
+    }
+    let entries;
+    try {
+      entries = await client.listListEntries(source, list.ListId, dateFrom);
+    } catch (error) {
+      listing.warnings.push(`list ${list.ListName}: ${errorText(error)}`);
+      continue;
+    }
+    const inWindow = entries.filter(
+      (entry) => !entry.MutationDate || entry.MutationDate.slice(0, 10) <= dateTo,
+    );
+    await mapLimit(inWindow, IBABS_ENTRY_CONCURRENCY, async (entry) => {
+      try {
+        const detail = await client.getListEntry(source, list.ListId, entry.EntryId);
+        listing.registerEntries += 1;
+        const documents = motionPattern.test(list.ListName)
+          ? normalizeIbabsMotionDocuments(
+              source,
+              normalizeIbabsMotion(source, list, entry, detail, []),
+              detail,
+            )
+          : normalizeIbabsRegisterDocuments(source, list, entry, detail);
+        for (const document of documents) {
+          listing.documentIds.add(document.id);
+        }
+      } catch (error) {
+        listing.warnings.push(`entry ${entry.EntryId}: ${errorText(error)}`);
+      }
+    });
+  }
+  return listing;
+}
+
+async function listGemeenteOplossingen(
+  source: GemeenteOplossingenSourceDefinition,
+  dateFrom: string,
+  dateTo: string,
+  client = new GemeenteOplossingenClient(source.baseUrl, source.apiVersion ?? "v1"),
+): Promise<SupplierDocumentListing> {
+  const listing: SupplierDocumentListing = {
+    documentIds: new Set(),
+    meetings: 0,
+    registerEntries: 0,
+    warnings: [],
+  };
+  for (const rawMeeting of await client.listMeetingsByDateRange(dateFrom, dateTo)) {
+    try {
+      const meeting = normalizeGoMeeting(source, rawMeeting);
+      listing.meetings += 1;
+      for (const document of normalizeGoDocuments(source, meeting)) {
+        listing.documentIds.add(document.id);
+      }
+    } catch (error) {
+      listing.warnings.push(`meeting: ${errorText(error)}`);
+    }
+  }
+  return listing;
+}
+
+const PARLAEUS_AGENDA_CONCURRENCY = 2;
+
+async function listParlaeus(
+  source: ParlaeusSourceDefinition,
+  dateFrom: string,
+  dateTo: string,
+  client = new ParlaeusClient(source.baseUrl, source.sessionId),
+): Promise<SupplierDocumentListing> {
+  const listing: SupplierDocumentListing = {
+    documentIds: new Set(),
+    meetings: 0,
+    registerEntries: 0,
+    warnings: [],
+  };
+  const summaries = await client.listAgendaSummaries(dateFrom, dateTo);
+  await mapLimit(summaries, PARLAEUS_AGENDA_CONCURRENCY, async (summary) => {
+    try {
+      const { detail } = await client.getAgendaDetail(summary.agid);
+      const { documents } = normalizeParlaeusAgenda(source, detail);
+      listing.meetings += 1;
+      for (const document of documents) {
+        listing.documentIds.add(document.id);
+      }
+    } catch (error) {
+      listing.warnings.push(`agenda ${summary.agid}: ${errorText(error)}`);
+    }
+  });
+  return listing;
+}
+
+/** List what the supplier exposes for the source in the window. */
+export function listSupplierDocuments(
+  source: SourceDefinition,
+  dateFrom: string,
+  dateTo: string,
+): Promise<SupplierDocumentListing> {
+  switch (source.supplier) {
+    case "notubiz":
+      return listNotubiz(source as NotubizSourceDefinition, dateFrom, dateTo);
+    case "ibabs":
+      return listIbabs(source as IbabsSourceDefinition, dateFrom, dateTo);
+    case "gemeenteoplossingen":
+      return listGemeenteOplossingen(
+        source as GemeenteOplossingenSourceDefinition,
+        dateFrom,
+        dateTo,
+      );
+    case "parlaeus":
+      return listParlaeus(source as ParlaeusSourceDefinition, dateFrom, dateTo);
+    default:
+      return Promise.reject(
+        new Error(`No coverage listing for supplier ${(source as SourceDefinition).supplier}`),
+      );
+  }
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export const __test__ = { listNotubiz, listIbabs, listGemeenteOplossingen, listParlaeus };

--- a/src/exports/log.ts
+++ b/src/exports/log.ts
@@ -117,8 +117,7 @@ export class ExportChangesLog {
     // but a range scan is guaranteed to use idx_export_entity_state_entity_id_op
     // regardless of SQLite version/collation quirks in the LIKE optimizer.
     const upperBound =
-      idPrefix.slice(0, -1) +
-      String.fromCharCode(idPrefix.charCodeAt(idPrefix.length - 1) + 1);
+      idPrefix.slice(0, -1) + String.fromCharCode(idPrefix.charCodeAt(idPrefix.length - 1) + 1);
     const row = this.db
       .prepare(
         `SELECT COUNT(*) AS count FROM export_entity_state
@@ -357,6 +356,21 @@ export class ExportChangesLog {
       nextCursor: String(nextCursor),
       hasMore: nextCursor < this.headNextSeq(sourceKey),
     };
+  }
+
+  /** Every live entity id of a source under an id prefix, without parsing a
+   * single record. Ids are `<type>:<supplier>:<orgType>:<key>:<native>`, so
+   * `document:` selects a source's documents as one primary-key range. The
+   * coverage check compares this against what the supplier lists. */
+  listEntityIds(sourceKey: string, prefix: string): string[] {
+    const rows = this.db
+      .prepare(
+        `SELECT entity_id FROM export_entity_state
+         WHERE source_key = ? AND op = 'upsert' AND entity_id >= ? AND entity_id < ?
+         ORDER BY entity_id`,
+      )
+      .all(sourceKey, prefix, `${prefix}\uffff`) as Array<{ entity_id: string }>;
+    return rows.map((row) => row.entity_id);
   }
 
   /** Read the current state per entity (latest upsert record, tombstones

--- a/src/ibabs/extractor.ts
+++ b/src/ibabs/extractor.ts
@@ -21,6 +21,7 @@ import {
   normalizeIbabsMeeting,
   normalizeIbabsMotion,
   normalizeIbabsMotionDocuments,
+  normalizeIbabsRegisterDocuments,
 } from "./normalize.ts";
 import { MeetingIndex, parseAgendaPointReference } from "../motions/normalize.ts";
 import { IbabsClient } from "./client.ts";
@@ -36,6 +37,10 @@ const MOTION_LIST_PATTERN = /moties?|amendement|stemming/i;
  * an unexpectedly wide window shouldn't be able to run for hours. Overruns are
  * reported as an issue rather than silently dropped. */
 const DEFAULT_MOTION_LIMIT = 750;
+/** Register entries per run. Registers are larger than motion lists -- an
+ * organisation's "Ingekomen stukken" easily runs to hundreds a year -- and
+ * cost one SOAP call each (no votes), so the cap is higher and separate. */
+const DEFAULT_REGISTER_LIMIT = 2000;
 /** Concurrency for the motion pass, deliberately below the document one.
  *
  * Motions are pure SOAP traffic against a single throttled endpoint, where
@@ -299,11 +304,53 @@ export class IbabsMeetingExtractor {
     // Motions run after every chunk so the meeting index covers the whole
     // window — a motion's agenda reference may point at a meeting from an
     // earlier chunk than the one it was mutated in.
+    // Motion and register attachments take the same path as meeting
+    // documents. A file seen twice in one run (agenda item and register, or
+    // two registers) is fetched once.
+    const listDocumentsSeen = new Set<string>();
+    const materializeListDocuments = async (listDocuments: DocumentEntity[]) => {
+      for (const document of listDocuments) {
+        if (listDocumentsSeen.has(document.id)) {
+          continue;
+        }
+        listDocumentsSeen.add(document.id);
+        try {
+          const materialized = await materializeDocument(document, {
+            download: (documentEntity) => this.client.downloadDocument(documentEntity),
+            storage,
+            executionMode: options.executionMode,
+          });
+          for (const issue of materialized.issues) {
+            await registerIssue(issue);
+          }
+          documentCount += 1;
+          if (retainEntities) {
+            documents.push(materialized.document);
+          }
+          if (materialized.cacheHit) {
+            cacheHits += 1;
+          } else {
+            downloadedCount += 1;
+          }
+          await options.onProgress?.(currentStats());
+          await options.onEntity?.(materialized.document);
+        } catch (error) {
+          await registerIssue({
+            severity: "error",
+            step: issueStepForDocumentError(error),
+            entity_id: document.id,
+            message: error instanceof Error ? error.message : "Document processing failed",
+          });
+        }
+      }
+    };
+
     await this.extractMotions(source, dateFrom, dateTo, {
       meetingIndex,
       meetingTypes: meetingTypeMap,
       concurrency: motionConcurrency,
       registerIssue,
+      onRegisterDocuments: materializeListDocuments,
       onMotion: async (motion, motionDocuments) => {
         motionCount += 1;
         if (retainEntities) {
@@ -311,37 +358,7 @@ export class IbabsMeetingExtractor {
         }
         await options.onProgress?.(currentStats());
         await options.onEntity?.(motion);
-
-        for (const document of motionDocuments) {
-          try {
-            const materialized = await materializeDocument(document, {
-              download: (documentEntity) => this.client.downloadDocument(documentEntity),
-              storage,
-              executionMode: options.executionMode,
-            });
-            for (const issue of materialized.issues) {
-              await registerIssue(issue);
-            }
-            documentCount += 1;
-            if (retainEntities) {
-              documents.push(materialized.document);
-            }
-            if (materialized.cacheHit) {
-              cacheHits += 1;
-            } else {
-              downloadedCount += 1;
-            }
-            await options.onProgress?.(currentStats());
-            await options.onEntity?.(materialized.document);
-          } catch (error) {
-            await registerIssue({
-              severity: "error",
-              step: issueStepForDocumentError(error),
-              entity_id: document.id,
-              message: error instanceof Error ? error.message : "Document processing failed",
-            });
-          }
-        }
+        await materializeListDocuments(motionDocuments);
       },
     });
 
@@ -369,10 +386,14 @@ export class IbabsMeetingExtractor {
       concurrency: number;
       registerIssue: (issue: ExtractionIssue) => Promise<void>;
       onMotion: (motion: MotionEntity, documents: DocumentEntity[]) => Promise<void>;
+      onRegisterDocuments: (documents: DocumentEntity[]) => Promise<void>;
     },
   ): Promise<void> {
     const limit = Number(Deno.env.get("WOOZI_IBABS_MOTION_LIMIT") ?? `${DEFAULT_MOTION_LIMIT}`);
-    if (limit <= 0) {
+    const registerLimit = Number(
+      Deno.env.get("WOOZI_IBABS_REGISTER_LIMIT") ?? `${DEFAULT_REGISTER_LIMIT}`,
+    );
+    if (limit <= 0 && registerLimit <= 0) {
       return;
     }
 
@@ -391,15 +412,29 @@ export class IbabsMeetingExtractor {
       return;
     }
 
-    const targets = lists.filter((list) => MOTION_LIST_PATTERN.test(list.ListName));
+    // Every list is either a motion list or a register. Motion lists keep
+    // their vote lookup and become Motion entities; every other list is a
+    // register whose attachments become Documents (see
+    // normalizeIbabsRegisterDocuments). Measured 2026-09-04 (#258): for
+    // Notubiz the same split explained 90% of the recent documents ORI held
+    // and we did not, and #226 measured 117,746 register entries ORI held
+    // across iBabs sources.
+    const isMotionList = (list: IbabsList) => MOTION_LIST_PATTERN.test(list.ListName);
+    const targets = lists.filter((list) =>
+      isMotionList(list) ? limit > 0 : registerLimit > 0 && list.ListName.trim().length > 0,
+    );
     if (targets.length === 0) {
       return;
     }
 
-    const pending: Array<{ list: IbabsList; entry: IbabsListEntryBase }> = [];
+    const pending: Array<{ list: IbabsList; entry: IbabsListEntryBase; motion: boolean }> = [];
     let skippedForLimit = 0;
+    let skippedForRegisterLimit = 0;
+    let pendingMotions = 0;
+    let pendingRegisters = 0;
 
     for (const list of targets) {
+      const motion = isMotionList(list);
       let entries: IbabsListEntryBase[];
       try {
         entries = await this.client.listListEntries(source, list.ListId, dateFrom);
@@ -419,12 +454,32 @@ export class IbabsMeetingExtractor {
         if (!isEntryInWindow(entry.MutationDate, dateFrom, dateTo)) {
           continue;
         }
-        if (pending.length >= limit) {
-          skippedForLimit += 1;
-          continue;
+        if (motion) {
+          if (pendingMotions >= limit) {
+            skippedForLimit += 1;
+            continue;
+          }
+          pendingMotions += 1;
+        } else {
+          if (pendingRegisters >= registerLimit) {
+            skippedForRegisterLimit += 1;
+            continue;
+          }
+          pendingRegisters += 1;
         }
-        pending.push({ list, entry });
+        pending.push({ list, entry, motion });
       }
+    }
+
+    if (skippedForRegisterLimit > 0) {
+      await context.registerIssue({
+        severity: "warning",
+        step: "list_motions",
+        entity_id: source.key,
+        message:
+          `iBabs ${source.ibabsSitename}: ${skippedForRegisterLimit} register entries skipped, over the ` +
+          `${registerLimit}-entry per-run cap (WOOZI_IBABS_REGISTER_LIMIT). Narrow the date range to import them.`,
+      });
     }
 
     if (skippedForLimit > 0) {
@@ -481,17 +536,31 @@ export class IbabsMeetingExtractor {
       return load;
     };
 
-    await mapLimit(pending, context.concurrency, async ({ list, entry }) => {
+    await mapLimit(pending, context.concurrency, async ({ list, entry, motion: isMotion }) => {
       try {
         const detail = await this.client.getListEntry(source, list.ListId, entry.EntryId);
-        // Empty for the ~half of sources without the digital voting module.
-        const votes = await this.client.getListEntryVotes(source, entry.EntryId);
 
         const reference = parseAgendaPointReference(detail.Values["Agendapunt"]);
         if (reference) {
           await ensureMeetingsForDate(reference.meetingDate);
         }
 
+        if (!isMotion) {
+          const documents = normalizeIbabsRegisterDocuments(
+            source,
+            list,
+            entry,
+            detail,
+            context.meetingIndex,
+          );
+          if (documents.length > 0) {
+            await context.onRegisterDocuments(documents);
+          }
+          return;
+        }
+
+        // Empty for the ~half of sources without the digital voting module.
+        const votes = await this.client.getListEntryVotes(source, entry.EntryId);
         const motion = normalizeIbabsMotion(
           source,
           list,

--- a/src/ibabs/normalize.ts
+++ b/src/ibabs/normalize.ts
@@ -85,7 +85,10 @@ function toAgendaDocumentLinks(
   return documents.length > 0 ? documents : undefined;
 }
 
-function collectAgendaItems(source: IbabsSourceDefinition, meeting: IbabsMeeting): MeetingAgendaItem[] {
+function collectAgendaItems(
+  source: IbabsSourceDefinition,
+  meeting: IbabsMeeting,
+): MeetingAgendaItem[] {
   return (meeting.MeetingItems ?? []).map((item: IbabsMeetingItem, index) => ({
     id: canonicalAgendaItemId(source, item.Id),
     title: item.Title,
@@ -195,15 +198,14 @@ export function normalizeIbabsMotion(
   meetings?: MeetingIndex,
 ): MotionEntity {
   const values = detail.Values;
-  const name = pickValue(values, ["Onderwerp", "Titel", "Toezegging"]) ??
+  const name =
+    pickValue(values, ["Onderwerp", "Titel", "Toezegging"]) ??
     entry.EntryTitle ??
     `${list.ListName} ${entry.EntryId}`;
   const status = pickValue(values, ["Status"]);
   const date = parseMotionDate(pickValue(values, ["Datum", "Datum motie", "Datum indiening"]));
 
-  const proposers = splitProposers(
-    pickValue(values, ["Indiener(s)", "Indieners", "Indiener"]),
-  );
+  const proposers = splitProposers(pickValue(values, ["Indiener(s)", "Indieners", "Indiener"]));
   const coProposers = splitProposers(
     pickValue(values, ["Mede-indieners", "Mede-indiener(s)", "Medeondertekenaars"]),
   );
@@ -282,6 +284,60 @@ export function normalizeIbabsMotionDocuments(
       canonical_id: document.Id,
       canonical_iri: `ibabs://${source.ibabsSitename}/document/${document.Id}`,
       source_iri: motion.source_info.canonical_iri,
+    },
+    raw: document,
+  }));
+}
+
+/** Documents of a register entry: ingekomen stukken, raadsvragen,
+ * toezeggingen, brieven aan de raad, and whatever other list an organisation
+ * keeps besides its meetings.
+ *
+ * ORI harvested these as `Report` entities with their attachments; 117,746 of
+ * them across all iBabs sources (#226), most of them dated 2025 and 2026. The
+ * entry itself is not projected here -- its attachments are, as Documents
+ * classified by the list's name, referenced by the meeting the entry's
+ * "Agendapunt" resolves to and by the organisation otherwise. A file that
+ * also hangs off an agenda item keeps its id and stays one entity. */
+export function normalizeIbabsRegisterDocuments(
+  source: IbabsSourceDefinition,
+  list: IbabsList,
+  entry: IbabsListEntryBase,
+  detail: IbabsListEntryDetail,
+  meetings?: MeetingIndex,
+): DocumentEntity[] {
+  const values = detail.Values;
+  const title =
+    pickValue(values, ["Onderwerp", "Titel", "Toezegging", "Vraag"]) ??
+    entry.EntryTitle ??
+    `${list.ListName} ${entry.EntryId}`;
+  const date =
+    parseMotionDate(
+      pickValue(values, ["Datum", "Datum ontvangst", "Datum indiening", "Datum toezegging"]),
+    ) ?? parseMotionDate(entry.MutationDate);
+  const reference = parseAgendaPointReference(pickValue(values, ["Agendapunt"]));
+  const meeting = reference && meetings ? meetings.find(reference) : undefined;
+  const sourceIri = `ibabs://${source.ibabsSitename}/listentry/${entry.EntryId}`;
+
+  return detail.Documents.map((document) => ({
+    id: canonicalDocumentId(source, document.Id),
+    type: "Document",
+    name: document.DisplayName?.trim() || document.FileName?.trim() || title,
+    classification: [list.ListName],
+    original_url: document.PublicDownloadURL,
+    identifier_url: `ibabs://${source.ibabsSitename}/document/${document.Id}`,
+    file_name: document.FileName,
+    size_in_bytes: document.FileSize,
+    last_discussed_at: meeting?.start_date ?? date,
+    is_referenced_by: meeting?.id ?? canonicalOrganizationId(source),
+    organization: canonicalOrganizationId(source),
+    source_info: {
+      supplier: source.supplier,
+      source: source.key,
+      organization_type: source.organizationType,
+      canonical_id: document.Id,
+      canonical_iri: `ibabs://${source.ibabsSitename}/document/${document.Id}`,
+      source_iri: sourceIri,
     },
     raw: document,
   }));

--- a/src/notubiz/extractor.ts
+++ b/src/notubiz/extractor.ts
@@ -5,8 +5,10 @@ import { canonicalMeetingId } from "../ids.ts";
 import { normalizeNotubizDocuments, normalizeNotubizMeeting } from "./normalize.ts";
 import {
   isMotionModule,
+  isRegisterModule,
   normalizeNotubizMotion,
   normalizeNotubizMotionDocuments,
+  normalizeNotubizRegisterDocuments,
 } from "./motions.ts";
 import { normalizeNotubizRecording } from "./recordings.ts";
 import { storeTranscript } from "../recordings/storage.ts";
@@ -353,6 +355,47 @@ export class NotubizMeetingExtractor {
     // recordings, and the registries were already imported by the run that
     // brought in these meetings.
     if (!mediaOnly) {
+      // Register and motion attachments take the same path as meeting
+      // documents: cache check, download, extraction, BSN scan. A document
+      // already seen under an agenda item in this run is not fetched twice.
+      const moduleDocumentsSeen = new Set<string>();
+      const materializeModuleDocuments = async (moduleDocuments: DocumentEntity[]) => {
+        await mapLimit(moduleDocuments, documentConcurrency, async (document) => {
+          if (moduleDocumentsSeen.has(document.id)) {
+            return;
+          }
+          moduleDocumentsSeen.add(document.id);
+          try {
+            const materialized = await materializeDocument(document, {
+              download: (documentEntity) => this.client.downloadDocument(documentEntity),
+              storage,
+              executionMode: options.executionMode,
+            });
+            for (const issue of materialized.issues) {
+              await registerIssue(issue);
+            }
+            documentCount += 1;
+            if (retainEntities) {
+              documents.push(materialized.document);
+            }
+            if (materialized.cacheHit) {
+              cacheHits += 1;
+            } else {
+              downloadedCount += 1;
+            }
+            await options.onProgress?.(currentStats());
+            await options.onEntity?.(materialized.document);
+          } catch (error) {
+            await registerIssue({
+              severity: "error",
+              step: issueStepForDocumentError(error),
+              entity_id: document.id,
+              message: error instanceof Error ? error.message : "Document processing failed",
+            });
+          }
+        });
+      };
+
       await this.extractMotions(source, dateFrom, dateTo, {
         meetingIndex,
         registerIssue,
@@ -363,38 +406,9 @@ export class NotubizMeetingExtractor {
           }
           await options.onProgress?.(currentStats());
           await options.onEntity?.(motion);
-
-          await mapLimit(motionDocuments, documentConcurrency, async (document) => {
-            try {
-              const materialized = await materializeDocument(document, {
-                download: (documentEntity) => this.client.downloadDocument(documentEntity),
-                storage,
-                executionMode: options.executionMode,
-              });
-              for (const issue of materialized.issues) {
-                await registerIssue(issue);
-              }
-              documentCount += 1;
-              if (retainEntities) {
-                documents.push(materialized.document);
-              }
-              if (materialized.cacheHit) {
-                cacheHits += 1;
-              } else {
-                downloadedCount += 1;
-              }
-              await options.onProgress?.(currentStats());
-              await options.onEntity?.(materialized.document);
-            } catch (error) {
-              await registerIssue({
-                severity: "error",
-                step: issueStepForDocumentError(error),
-                entity_id: document.id,
-                message: error instanceof Error ? error.message : "Document processing failed",
-              });
-            }
-          });
+          await materializeModuleDocuments(motionDocuments);
         },
+        onRegisterDocuments: materializeModuleDocuments,
       });
     }
 
@@ -501,6 +515,7 @@ export class NotubizMeetingExtractor {
       meetingIndex: MeetingIndex;
       registerIssue: (issue: ExtractionIssue) => Promise<void>;
       onMotion: (motion: MotionEntity, documents: DocumentEntity[]) => Promise<void>;
+      onRegisterDocuments: (documents: DocumentEntity[]) => Promise<void>;
     },
   ): Promise<void> {
     let modules: NotubizModule[];
@@ -518,7 +533,7 @@ export class NotubizMeetingExtractor {
       return;
     }
 
-    for (const module of modules.filter(isMotionModule)) {
+    for (const module of modules.filter((m) => isMotionModule(m) || isRegisterModule(m))) {
       let items: NotubizModuleItem[];
       try {
         items = await this.client.listModuleItems(
@@ -540,8 +555,23 @@ export class NotubizMeetingExtractor {
       }
 
       for (const item of items) {
-        const motion = normalizeNotubizMotion(source, module, item, context.meetingIndex);
-        await context.onMotion(motion, normalizeNotubizMotionDocuments(source, motion, item));
+        if (item.permission_group && item.permission_group !== "public") {
+          continue;
+        }
+        if (isMotionModule(module)) {
+          const motion = normalizeNotubizMotion(source, module, item, context.meetingIndex);
+          await context.onMotion(motion, normalizeNotubizMotionDocuments(source, motion, item));
+        } else {
+          const documents = normalizeNotubizRegisterDocuments(
+            source,
+            module,
+            item,
+            context.meetingIndex,
+          );
+          if (documents.length > 0) {
+            await context.onRegisterDocuments(documents);
+          }
+        }
       }
     }
   }

--- a/src/notubiz/motions.ts
+++ b/src/notubiz/motions.ts
@@ -4,14 +4,12 @@ import {
   canonicalMotionId,
   canonicalOrganizationId,
 } from "../ids.ts";
-import {
-  type MeetingIndex,
-  normalizeMotionResult,
-  parseMotionDate,
-} from "../motions/normalize.ts";
+import { type MeetingIndex, normalizeMotionResult, parseMotionDate } from "../motions/normalize.ts";
+import { normalizeDateTime } from "./normalize.ts";
 import type {
   DocumentEntity,
   MotionEntity,
+  NotubizAttachmentDocument,
   NotubizModule,
   NotubizModuleItem,
   NotubizModuleItemAttribute,
@@ -49,6 +47,20 @@ export function isMotionModule(module: NotubizModule): boolean {
   return MOTION_MODULE_PATTERN.test(module.name?.trim() ?? "");
 }
 
+/** Every other module is a register: Ingekomen stukken, Raadsvoorstellen,
+ * Schriftelijke vragen, Toezeggingen, Bestuursdocumenten, and whatever an
+ * organisation adds. Their items are not projected as entities of their own;
+ * their attachments are, as Documents classified by the module's name.
+ *
+ * Measured 2026-09-04 (#258): of 40 Ermelo documents from 2025 that the old
+ * ORI held and we did not, 24 sat in "Ingekomen stukken", 11 in
+ * "Raadsvoorstellen" and 1 in "Moties" -- none under an agenda item any more.
+ * Notubiz organisations moved their publishing into these registers during
+ * 2025, so a meeting-only harvest keeps the history and misses the present. */
+export function isRegisterModule(module: NotubizModule): boolean {
+  return !isMotionModule(module) && (module.name?.trim().length ?? 0) > 0;
+}
+
 function attributesById(item: NotubizModuleItem): Map<number, NotubizModuleItemAttribute> {
   const map = new Map<number, NotubizModuleItemAttribute>();
   for (const attribute of item.attributes ?? []) {
@@ -80,9 +92,9 @@ function referenceIds(
 ): string[] {
   return (attribute?.values ?? [])
     .filter((value) => value.meta_data?.reference_model === referenceModel)
-    .map((value) => (value.content === null || value.content === undefined
-      ? undefined
-      : String(value.content)))
+    .map((value) =>
+      value.content === null || value.content === undefined ? undefined : String(value.content),
+    )
     .filter((id): id is string => Boolean(id));
 }
 
@@ -117,8 +129,10 @@ export function htmlToText(value: string): string {
  * stemming gebracht"). Prefer whichever candidate maps onto a real outcome,
  * and fall back to field 62 verbatim so nothing is silently dropped. */
 function pickStatus(attributes: Map<number, NotubizModuleItemAttribute>): string | undefined {
-  const candidates = [textOf(attributes.get(FIELD.outcome)), textOf(attributes.get(FIELD.status))]
-    .filter((value): value is string => Boolean(value));
+  const candidates = [
+    textOf(attributes.get(FIELD.outcome)),
+    textOf(attributes.get(FIELD.status)),
+  ].filter((value): value is string => Boolean(value));
 
   const decisive = candidates.find((value) => normalizeMotionResult(value) !== "overig");
   return decisive ?? candidates[0];
@@ -185,8 +199,9 @@ export function normalizeNotubizMotion(
   const coProposers = labelsOf(attributes.get(FIELD.coSigners));
   const date = parseMotionDate(textOf(attributes.get(FIELD.date)));
 
-  const documentIds = referenceIds(attributes.get(FIELD.mainDocument), "document")
-    .map((id) => canonicalDocumentId(source, id));
+  const documentIds = referenceIds(attributes.get(FIELD.mainDocument), "document").map((id) =>
+    canonicalDocumentId(source, id),
+  );
 
   return {
     id: canonicalMotionId(source, item.id),
@@ -208,8 +223,8 @@ export function normalizeNotubizMotion(
     agenda_item: agendaItem,
     agenda_item_hint: meeting
       ? undefined
-      : labelsOf(attributes.get(FIELD.agendaItem))[0] ??
-        labelsOf(attributes.get(FIELD.linkedEvent))[0],
+      : (labelsOf(attributes.get(FIELD.agendaItem))[0] ??
+        labelsOf(attributes.get(FIELD.linkedEvent))[0]),
     attachment: documentIds.length > 0 ? documentIds : undefined,
     organization: canonicalOrganizationId(source),
     last_discussed_at: meetingStart ?? date,
@@ -224,43 +239,149 @@ export function normalizeNotubizMotion(
   };
 }
 
-/** Documents attached to a Notubiz motion.
+/** The documents a module item carries, from `attachments.document`.
  *
- * Only the main document (field 2) is materialized. `attachments.document`
- * also carries bijlagen, but those are already reachable through the agenda
- * item and would double the download load for little gain. */
+ * This used to read only the main document (field 2) and match it on
+ * `meta_data.reference_model === "document"`. Real items put the document
+ * under `value.document` with `meta_data: null`, so that filter matched
+ * nothing and Notubiz motions shipped without a single attachment (both
+ * fixtures reproduce it). `attachments.document` is the list Notubiz itself
+ * maintains and it carries what the cache key and the download need: file
+ * name, size, mime type, version and modification time. Confidential
+ * attachments are skipped; the item itself is already public. */
+function attachmentDocuments(item: NotubizModuleItem): NotubizAttachmentDocument[] {
+  const list = item.attachments?.document;
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  return list.filter(
+    (document): document is NotubizAttachmentDocument =>
+      Boolean(document && typeof document === "object" && typeof document.id === "number") &&
+      !(document as NotubizAttachmentDocument).confidential,
+  );
+}
+
+function normalizeAttachmentDocument(
+  source: NotubizSourceDefinition,
+  document: NotubizAttachmentDocument,
+  context: {
+    name: string;
+    classification: string[];
+    referencedBy: string;
+    lastDiscussedAt?: string;
+    sourceIri?: string;
+  },
+  item: NotubizModuleItem,
+): DocumentEntity {
+  const documentId = String(document.id);
+  const version = document.version ?? 1;
+  const file =
+    document.versions?.find((candidate) => candidate.id === version) ?? document.versions?.[0];
+  const dateModified = normalizeDateTime(document.last_modified);
+  return {
+    id: canonicalDocumentId(source, documentId),
+    type: "Document",
+    name: document.title?.trim() || file?.file_name || context.name,
+    classification: context.classification,
+    original_url: document.url ?? `https://api.notubiz.nl/document/${documentId}/${version}`,
+    identifier_url: `https://api.notubiz.nl/document/${documentId}`,
+    file_name: file?.file_name,
+    content_type: file?.mime_type,
+    size_in_bytes: file?.file_size,
+    date_modified: dateModified,
+    last_discussed_at: context.lastDiscussedAt,
+    is_referenced_by: context.referencedBy,
+    organization: canonicalOrganizationId(source),
+    source_info: {
+      supplier: source.supplier,
+      source: source.key,
+      organization_type: source.organizationType,
+      canonical_id: documentId,
+      canonical_iri: `https://api.notubiz.nl/document/${documentId}`,
+      source_iri: context.sourceIri,
+    },
+    // `version` and `last_modified` feed the cache key (see cacheVersionToken
+    // in src/documents/process.ts), so a re-published document is fetched
+    // again instead of served from the copy of its first version.
+    raw: {
+      id: documentId,
+      version,
+      last_modified: document.last_modified,
+      module_item: item.id,
+    },
+  };
+}
+
+/** Documents attached to a Notubiz motion. */
 export function normalizeNotubizMotionDocuments(
   source: NotubizSourceDefinition,
   motion: MotionEntity,
   item: NotubizModuleItem,
 ): DocumentEntity[] {
-  const attributes = attributesById(item);
-  const main = attributes.get(FIELD.mainDocument);
-
-  return (main?.values ?? [])
-    .filter((value) => value.meta_data?.reference_model === "document")
-    .map((value) => String(value.content))
-    .filter((id) => id && id !== "null" && id !== "undefined")
-    .map((documentId) => ({
-      id: canonicalDocumentId(source, documentId),
-      type: "Document" as const,
-      name: motion.name,
-      classification: [motion.motion_type ?? "Motie"],
-      original_url: `https://api.notubiz.nl/document/${documentId}/1`,
-      identifier_url: `https://api.notubiz.nl/document/${documentId}`,
-      last_discussed_at: motion.last_discussed_at,
-      is_referenced_by: motion.id,
-      organization: motion.organization,
-      source_info: {
-        supplier: source.supplier,
-        source: source.key,
-        organization_type: source.organizationType,
-        canonical_id: documentId,
-        canonical_iri: `https://api.notubiz.nl/document/${documentId}`,
-        source_iri: motion.source_info.canonical_iri,
+  return attachmentDocuments(item).map((document) =>
+    normalizeAttachmentDocument(
+      source,
+      document,
+      {
+        name: motion.name,
+        classification: [motion.motion_type ?? "Motie"],
+        referencedBy: motion.id,
+        lastDiscussedAt: motion.last_discussed_at,
+        sourceIri: motion.source_info.canonical_iri,
       },
-      raw: { id: documentId, motion: motion.id },
-    }));
+      item,
+    ),
+  );
+}
+
+/** Documents of a register item (any non-motion module).
+ *
+ * The item is dated by its own date field, or by the meeting its agenda
+ * reference resolves to; it is referenced by that meeting when there is one
+ * and by the organisation otherwise, so a reader can still see which council
+ * published it. The item's title is the name of a document that has none. */
+export function normalizeNotubizRegisterDocuments(
+  source: NotubizSourceDefinition,
+  module: NotubizModule,
+  item: NotubizModuleItem,
+  meetings?: MeetingIndex,
+): DocumentEntity[] {
+  const attributes = attributesById(item);
+  const title = textOf(attributes.get(FIELD.title)) ?? `${module.name} ${item.id}`;
+  const date = parseMotionDate(textOf(attributes.get(FIELD.date)));
+
+  const agendaItemIds = [
+    ...referenceIds(attributes.get(FIELD.agendaItem), "agenda_item"),
+    ...referenceIds(attributes.get(FIELD.linkedEvent), "agenda_item"),
+  ].map((id) => canonicalAgendaItemId(source, id));
+  let referencedBy = canonicalOrganizationId(source);
+  let meetingStart: string | undefined;
+  for (const candidate of agendaItemIds) {
+    const owner = meetings?.findByAgendaItem(candidate);
+    if (owner) {
+      referencedBy = owner.id;
+      meetingStart = owner.start_date;
+      break;
+    }
+  }
+
+  return attachmentDocuments(item).map((document) =>
+    normalizeAttachmentDocument(
+      source,
+      document,
+      {
+        name: title,
+        classification: [module.name],
+        referencedBy,
+        lastDiscussedAt:
+          meetingStart ??
+          date ??
+          (document.publication_date ? parseMotionDate(document.publication_date) : undefined),
+        sourceIri: `https://api.notubiz.nl/modules/${module.id}/items/${item.id}`,
+      },
+      item,
+    ),
+  );
 }
 
 export const __test__ = { FIELD, pickStatus, pickVoteSummary, attributesById };

--- a/src/notubiz/normalize.ts
+++ b/src/notubiz/normalize.ts
@@ -52,7 +52,10 @@ function canonicalDocumentDownloadUrl(documentId: string): string {
   return `https://api.notubiz.nl/document/${documentId}/1`;
 }
 
-function agendaAttributeValue(typeData: Record<string, unknown> | undefined, id: number): string | undefined {
+function agendaAttributeValue(
+  typeData: Record<string, unknown> | undefined,
+  id: number,
+): string | undefined {
   const attributes = Array.isArray(typeData?.attributes) ? typeData.attributes : [];
   for (const attribute of attributes) {
     if (!attribute || typeof attribute !== "object") {
@@ -107,7 +110,9 @@ export function normalizeNotubizAgendaItems(
           : undefined;
       const agendaId = canonicalAgendaItemId(source, id);
       const documents = (Array.isArray(record.documents) ? record.documents : [])
-        .filter((document): document is Record<string, unknown> => Boolean(document && typeof document === "object"))
+        .filter((document): document is Record<string, unknown> =>
+          Boolean(document && typeof document === "object"),
+        )
         .map((document) => normalizeAgendaDocumentLink(source, document))
         .filter((document): document is MeetingAgendaDocumentLink => Boolean(document));
       const children = normalizeNotubizAgendaItems(
@@ -116,20 +121,22 @@ export function normalizeNotubizAgendaItems(
         agendaId,
       );
 
-      return [{
-        id: agendaId,
-        parent: parentId,
-        title: agendaAttributeValue(typeData, 1),
-        description: agendaAttributeValue(typeData, 3),
-        number: typeof typeData?.title_prefix === "string" ? typeData.title_prefix : undefined,
-        order: typeof record.order === "number" ? record.order : undefined,
-        classification: typeof record.type === "string" ? record.type : undefined,
-        is_heading: typeData?.heading === true,
-        start_date: normalizeDateTime(record.start_date),
-        end_date: normalizeDateTime(record.end_date),
-        documents: documents.length > 0 ? documents : undefined,
-        agenda_items: children.length > 0 ? children : undefined,
-      }];
+      return [
+        {
+          id: agendaId,
+          parent: parentId,
+          title: agendaAttributeValue(typeData, 1),
+          description: agendaAttributeValue(typeData, 3),
+          number: typeof typeData?.title_prefix === "string" ? typeData.title_prefix : undefined,
+          order: typeof record.order === "number" ? record.order : undefined,
+          classification: typeof record.type === "string" ? record.type : undefined,
+          is_heading: typeData?.heading === true,
+          start_date: normalizeDateTime(record.start_date),
+          end_date: normalizeDateTime(record.end_date),
+          documents: documents.length > 0 ? documents : undefined,
+          agenda_items: children.length > 0 ? children : undefined,
+        },
+      ];
     });
 }
 
@@ -197,7 +204,7 @@ function documentClassification(document: Record<string, unknown>): string[] | u
   return values.length > 0 ? values : undefined;
 }
 
-function normalizeDateTime(value: unknown): string | undefined {
+export function normalizeDateTime(value: unknown): string | undefined {
   if (typeof value !== "string" || value.length === 0) {
     return undefined;
   }
@@ -281,7 +288,10 @@ export function normalizeNotubizMeeting(
       typeof gremiumId === "number" || typeof gremiumId === "string"
         ? canonicalCommitteeId(source, gremiumId)
         : undefined,
-    agenda: normalizeNotubizAgendaItems(source, Array.isArray(record.agenda_items) ? record.agenda_items : []),
+    agenda: normalizeNotubizAgendaItems(
+      source,
+      Array.isArray(record.agenda_items) ? record.agenda_items : [],
+    ),
     attachment: collectAttachmentIds(source, record),
     source_info: {
       supplier: "notubiz",

--- a/src/ops/store.ts
+++ b/src/ops/store.ts
@@ -92,7 +92,22 @@ async function getDatabase(): Promise<DatabaseSync> {
           streak INTEGER NOT NULL DEFAULT 0,
           last_checked_at TEXT NOT NULL
         );
-        CREATE TABLE IF NOT EXISTS revalidation_cursor (
+        CREATE TABLE IF NOT EXISTS coverage_check (
+        source_key TEXT NOT NULL,
+        checked_at TEXT NOT NULL,
+        window_from TEXT NOT NULL,
+        window_to TEXT NOT NULL,
+        supplier_documents INTEGER NOT NULL,
+        held_documents INTEGER NOT NULL,
+        missing_documents INTEGER NOT NULL,
+        missing_sample TEXT NOT NULL,
+        supplier_meetings INTEGER NOT NULL,
+        register_entries INTEGER NOT NULL,
+        warnings INTEGER NOT NULL,
+        error TEXT,
+        PRIMARY KEY (source_key, checked_at)
+      );
+      CREATE TABLE IF NOT EXISTS revalidation_cursor (
           supplier TEXT PRIMARY KEY,
           start_offset INTEGER NOT NULL DEFAULT 0
         );
@@ -214,8 +229,11 @@ export async function getRunIssueCount(runId: string): Promise<number> {
 
 function normalizeTrigger(trigger: string): IngestRunTrigger {
   if (
-    trigger === "scheduled" || trigger === "user" || trigger === "manual" ||
-    trigger === "api" || trigger === "backfill"
+    trigger === "scheduled" ||
+    trigger === "user" ||
+    trigger === "manual" ||
+    trigger === "api" ||
+    trigger === "backfill"
   ) {
     return trigger;
   }
@@ -1149,4 +1167,84 @@ export async function listConfirmedGoneDocuments(
        ORDER BY streak DESC`,
     )
     .all({ supplier, threshold }) as unknown as RevalidationEntry[];
+}
+
+/** One coverage check of one source: what the supplier listed for the window
+ * against what the export log held. See src/coverage/check.ts. */
+export interface CoverageCheckRecord {
+  source_key: string;
+  checked_at: string;
+  window_from: string;
+  window_to: string;
+  supplier_documents: number;
+  held_documents: number;
+  missing_documents: number;
+  missing_sample: string[];
+  supplier_meetings: number;
+  register_entries: number;
+  /** Supplier requests that failed during the listing; the supplier count is
+   * then a lower bound. */
+  warnings: number;
+  /** Set when the listing itself failed and the counts are meaningless. */
+  error?: string;
+}
+
+export async function recordCoverageCheck(record: CoverageCheckRecord): Promise<void> {
+  const db = await getDatabase();
+  db.prepare(
+    `INSERT INTO coverage_check (
+       source_key, checked_at, window_from, window_to, supplier_documents, held_documents,
+       missing_documents, missing_sample, supplier_meetings, register_entries, warnings, error
+     ) VALUES (
+       @source_key, @checked_at, @window_from, @window_to, @supplier_documents, @held_documents,
+       @missing_documents, @missing_sample, @supplier_meetings, @register_entries, @warnings, @error
+     )
+     ON CONFLICT(source_key, checked_at) DO UPDATE SET
+       supplier_documents = excluded.supplier_documents,
+       held_documents = excluded.held_documents,
+       missing_documents = excluded.missing_documents,
+       missing_sample = excluded.missing_sample,
+       supplier_meetings = excluded.supplier_meetings,
+       register_entries = excluded.register_entries,
+       warnings = excluded.warnings,
+       error = excluded.error`,
+  ).run({
+    source_key: record.source_key,
+    checked_at: record.checked_at,
+    window_from: record.window_from,
+    window_to: record.window_to,
+    supplier_documents: record.supplier_documents,
+    held_documents: record.held_documents,
+    missing_documents: record.missing_documents,
+    missing_sample: JSON.stringify(record.missing_sample),
+    supplier_meetings: record.supplier_meetings,
+    register_entries: record.register_entries,
+    warnings: record.warnings,
+    error: record.error ?? null,
+  });
+}
+
+/** The latest check per source. */
+export async function latestCoverageChecks(): Promise<CoverageCheckRecord[]> {
+  const db = await getDatabase();
+  const rows = db
+    .prepare(
+      `SELECT source_key, checked_at, window_from, window_to, supplier_documents, held_documents,
+              missing_documents, missing_sample, supplier_meetings, register_entries, warnings, error
+       FROM (
+         SELECT *, ROW_NUMBER() OVER (PARTITION BY source_key ORDER BY checked_at DESC) AS rn
+         FROM coverage_check
+       ) WHERE rn = 1`,
+    )
+    .all() as unknown as Array<
+    Omit<CoverageCheckRecord, "missing_sample" | "error"> & {
+      missing_sample: string;
+      error: string | null;
+    }
+  >;
+  return rows.map((row) => ({
+    ...row,
+    missing_sample: JSON.parse(row.missing_sample) as string[],
+    error: row.error ?? undefined,
+  }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -900,6 +900,30 @@ export interface SourceStatus {
    * successor, so a caller can follow the trail. */
   discontinuedAt?: string;
   succeededBy?: { cbsId: string; label: string; sourceKey?: string };
+  /** The most recent coverage check for this source, when one has run: what
+   * the supplier's own API listed for a date window against what we hold.
+   * Absent until the weekly check has covered the source. */
+  coverage?: SourceCoverage;
+}
+
+/** Result of one coverage check (src/coverage/check.ts). `heldDocuments` and
+ * `missingDocuments` partition `supplierDocuments`; `ratio` is held over
+ * supplier, 1 meaning every document the supplier lists is in the index.
+ * `lowerBound` is true when some supplier requests failed, so the supplier
+ * count (and the gap) may be larger than reported. */
+export interface SourceCoverage {
+  checkedAt: string;
+  windowFrom: string;
+  windowTo: string;
+  supplierDocuments: number;
+  heldDocuments: number;
+  missingDocuments: number;
+  ratio: number;
+  lowerBound: boolean;
+  /** A few of the missing document ids, for a human to verify. */
+  missingSample: string[];
+  /** Set when the check itself failed for this source. */
+  error?: string;
 }
 
 /** `down` is the shape of #205: every run against a supplier failing, for as

--- a/src/types.ts
+++ b/src/types.ts
@@ -432,14 +432,30 @@ export interface NotubizModuleItemAttribute {
   values?: NotubizModuleItemValue[];
 }
 
+/** A document as Notubiz lists it under a module item's `attachments`.
+ * Richer than the field-2 reference: it carries the file name, size, version
+ * and modification time the cache key and the download need. */
+export interface NotubizAttachmentDocument {
+  id: number;
+  /** `https://api.notubiz.nl/document/{id}/{version}` */
+  url?: string;
+  title?: string;
+  publication_date?: string;
+  last_modified?: string;
+  version?: number;
+  confidential?: number;
+  versions?: Array<{ id?: number; mime_type?: string; file_name?: string; file_size?: number }>;
+}
+
 export interface NotubizModuleItem {
   id: number;
   module_id?: number;
   organisation_id?: number;
   last_modified?: string;
+  permission_group?: string;
   attributes?: NotubizModuleItemAttribute[];
   attachments?: {
-    document?: unknown[];
+    document?: NotubizAttachmentDocument[];
   };
 }
 

--- a/tests/coverage_check.test.ts
+++ b/tests/coverage_check.test.ts
@@ -1,0 +1,136 @@
+// The ops store opens its database at import time from WOOZI_KV_PATH, so the
+// path is set before the store is imported (same pattern as
+// tests/ops_ingest_status.test.ts).
+Deno.env.set("WOOZI_KV_PATH", await Deno.makeTempFile({ suffix: ".sqlite3" }));
+
+import { assertEquals } from "jsr:@std/assert";
+import { __test__, compareCoverage } from "../src/coverage/check.ts";
+import { latestCoverageChecks, recordCoverageCheck } from "../src/ops/store.ts";
+import { getNotubizSource } from "../src/sources/index.ts";
+import { __test__ as statusTest } from "../web/status_api.ts";
+
+Deno.test("coverage compares what the supplier lists against what we hold", () => {
+  const comparison = compareCoverage(
+    ["document:x:1", "document:x:2", "document:x:3"],
+    ["document:x:2", "document:x:9"],
+  );
+  assertEquals(comparison.supplierDocuments, 3);
+  assertEquals(comparison.heldDocuments, 1);
+  assertEquals(comparison.missingDocuments, 2);
+  assertEquals(comparison.missingSample, ["document:x:1", "document:x:3"]);
+  // What we hold beyond the supplier's listing is not a gap.
+  assertEquals(compareCoverage([], ["document:x:9"]).missingDocuments, 0);
+});
+
+Deno.test("a Notubiz listing counts meeting documents and register attachments alike", async () => {
+  const source = getNotubizSource("ermelo");
+  const registerItems = JSON.parse(
+    await Deno.readTextFile(
+      new URL("./fixtures/notubiz_ermelo_ingekomen_stukken.json", import.meta.url),
+    ),
+  ).items;
+  const fakeClient = {
+    getOrganizationAttributes: () => Promise.resolve({ attributes: {} }),
+    listEvents: (_org: number, _from: string, _to: string, page: number) =>
+      Promise.resolve(
+        page === 1
+          ? {
+              events: [
+                { id: 501, permission_group: "public" },
+                { id: 502, permission_group: "private" },
+              ],
+              pagination: { has_more_pages: false },
+            }
+          : { events: [] },
+      ),
+    getMeeting: (id: number) =>
+      Promise.resolve({
+        meeting: {
+          id,
+          title: "Raad",
+          plannings: [{ start_date: "2026-01-14 19:30:00" }],
+          gremium: { name: "Gemeenteraad" },
+          agenda_items: [
+            {
+              id: 9001,
+              type_data: { title: "Opening" },
+              documents: [
+                { id: 700, url: "https://api.notubiz.nl/document/700/1", title: "Agenda" },
+              ],
+            },
+          ],
+          documents: [],
+        },
+      }),
+    listModules: () =>
+      Promise.resolve([
+        { id: 1, name: "Ingekomen stukken" },
+        { id: 6, name: "Moties" },
+      ]),
+    listModuleItems: (_org: number, moduleId: number) =>
+      Promise.resolve(moduleId === 1 ? registerItems : []),
+  };
+
+  const listing = await __test__.listNotubiz(
+    source,
+    "2026-01-01",
+    "2026-12-31",
+    // deno-lint-ignore no-explicit-any
+    fakeClient as any,
+  );
+  assertEquals(listing.meetings, 1, "only the public meeting is fetched");
+  assertEquals(listing.registerEntries, 2, "both register items are listed");
+  assertEquals(listing.warnings, []);
+  // 1 agenda document + 7 + 1 register attachments
+  assertEquals(listing.documentIds.size, 9);
+  assertEquals(listing.documentIds.has("document:notubiz:gemeente:ermelo:700"), true);
+  assertEquals(listing.documentIds.has("document:notubiz:gemeente:ermelo:16387622"), true);
+});
+
+Deno.test("a recorded check surfaces on the status response as coverage", async () => {
+  await recordCoverageCheck({
+    source_key: "ermelo",
+    checked_at: "2026-09-07T05:00:00.000Z",
+    window_from: "2025-09-07",
+    window_to: "2026-09-07",
+    supplier_documents: 1547,
+    held_documents: 170,
+    missing_documents: 1377,
+    missing_sample: ["document:notubiz:gemeente:ermelo:15155760"],
+    supplier_meetings: 68,
+    register_entries: 540,
+    warnings: 0,
+  });
+  // A newer check replaces the older one in the latest view.
+  await recordCoverageCheck({
+    source_key: "ermelo",
+    checked_at: "2026-09-14T05:00:00.000Z",
+    window_from: "2025-09-14",
+    window_to: "2026-09-14",
+    supplier_documents: 1600,
+    held_documents: 1580,
+    missing_documents: 20,
+    missing_sample: [],
+    supplier_meetings: 70,
+    register_entries: 560,
+    warnings: 2,
+  });
+  const latest = await latestCoverageChecks();
+  const ermelo = latest.find((row) => row.source_key === "ermelo");
+  assertEquals(ermelo?.checked_at, "2026-09-14T05:00:00.000Z");
+  assertEquals(ermelo?.missing_sample, []);
+
+  const response = statusTest.buildStatusResponse({
+    runStatus: { sources: [], supplierWindows: [] },
+    indexActivity: null,
+    coverageChecks: latest,
+    now: Date.parse("2026-09-14T12:00:00Z"),
+    windowHours: 36,
+  });
+  const source = response.sources.find((row) => row.sourceKey === "ermelo");
+  assertEquals(source?.coverage?.supplierDocuments, 1600);
+  assertEquals(source?.coverage?.ratio, 0.988);
+  assertEquals(source?.coverage?.lowerBound, true, "two failed requests make it a lower bound");
+  const other = response.sources.find((row) => row.sourceKey === "dongen");
+  assertEquals(other?.coverage, undefined, "no check, no field");
+});

--- a/tests/fixtures/notubiz_ermelo_ingekomen_stukken.json
+++ b/tests/fixtures/notubiz_ermelo_ingekomen_stukken.json
@@ -1,0 +1,387 @@
+{
+  "items": [
+    {
+      "attachments": {
+        "document": [
+          {
+            "self": "api.notubiz.nl/document/16387622",
+            "url": "https://api.notubiz.nl/document/16387622/1",
+            "title": "Wegenbeheerplan 2026-2030 e250064948",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16387622,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Wegenbeheerplan 2026-2030 e250064948.pdf",
+                "file_size": 1630609,
+                "id": 1
+              }
+            ]
+          },
+          {
+            "self": "api.notubiz.nl/document/16504312",
+            "url": "https://api.notubiz.nl/document/16504312/2",
+            "title": "Vraag één-Ermelo informatiememo Wegenbeheerplan",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16504312,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 2,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Vraag één-Ermelo.pdf",
+                "file_size": 218094,
+                "id": 2
+              },
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Vraag één-Ermelo.pdf",
+                "file_size": 218094,
+                "id": 1
+              }
+            ]
+          },
+          {
+            "self": "api.notubiz.nl/document/16507416",
+            "url": "https://api.notubiz.nl/document/16507416/1",
+            "title": "Vragen Progressief Ermelo informatiememo Wegenbeheerplan",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16507416,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Vragen Progressief Ermelo informatiememo Wegenbeheerplan.pdf",
+                "file_size": 352388,
+                "id": 1
+              }
+            ]
+          },
+          {
+            "self": "api.notubiz.nl/document/16508676",
+            "url": "https://api.notubiz.nl/document/16508676/1",
+            "title": "Vragen CDA Informatiememo Wegenbeheerplan",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16508676,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Vragen CDA Informatiememo Wegenbeheerplan.pdf",
+                "file_size": 350224,
+                "id": 1
+              }
+            ]
+          },
+          {
+            "self": "api.notubiz.nl/document/16510048",
+            "url": "https://api.notubiz.nl/document/16510048/1",
+            "title": "Beantwoording vragen één-Ermelo, PE, CDA en Fietsersbond",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16510048,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Beantwoording vragen één-Ermelo, PE, CDA en Fietsersbond.pdf",
+                "file_size": 142954,
+                "id": 1
+              }
+            ]
+          },
+          {
+            "self": "api.notubiz.nl/document/16510229",
+            "url": "https://api.notubiz.nl/document/16510229/1",
+            "title": "Fietsersbond Inspraak wegenbeheerplan 21 januari 2026",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16510229,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Fietsersbond Inspraak wegenbeheerplan 21 januari 2026.pdf",
+                "file_size": 22136,
+                "id": 1
+              }
+            ]
+          },
+          {
+            "self": "api.notubiz.nl/document/16557209",
+            "url": "https://api.notubiz.nl/document/16557209/1",
+            "title": "Antwoord raadsvragen wegenbeheerplan nav beeldvormende avond 21 jan 2026 (1) (2) (1)",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16557209,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2026-02-05 11:51:47",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "Antwoord raadsvragen wegenbeheerplan nav beeldvormende avond 21 jan 2026 (1) (2) (1).pdf",
+                "file_size": 75468,
+                "id": 1
+              }
+            ]
+          }
+        ]
+      },
+      "id": 1114629,
+      "creation_date": null,
+      "last_modified": "2026-02-05 11:51:47",
+      "confidential": 0,
+      "body": null,
+      "permission_group": "public",
+      "organisation_id": 1550,
+      "module_id": 1,
+      "attributes": [
+        {
+          "label": "Onderwerp",
+          "id": 1,
+          "datatype": "varchar",
+          "order": 4,
+          "multiple": 0,
+          "visible": "both",
+          "values": [
+            {
+              "meta_data": null,
+              "content": "372-25 Informatiememo Wegenbeheerplan 2026-2030 "
+            }
+          ]
+        },
+        {
+          "label": "Datum vergadering",
+          "id": 15,
+          "datatype": "datetime",
+          "order": 8,
+          "multiple": 0,
+          "visible": "both",
+          "values": [
+            {
+              "meta_data": null,
+              "content": "2025-12-17 00:00:00"
+            }
+          ]
+        },
+        {
+          "label": "Gekoppeld evenement",
+          "id": 54,
+          "datatype": "integer",
+          "order": 11,
+          "multiple": 1,
+          "visible": "detail",
+          "values": [
+            {
+              "meta_data": {
+                "reference_model": "agenda_item",
+                "label": "Lijst ingekomen stukken raad 17 december 2025 (Raadsvergadering  17-12-2025 19:30)"
+              },
+              "content": 9893143
+            },
+            {
+              "meta_data": {
+                "reference_model": "agenda_item",
+                "label": "Informatiememo Wegenbeheerplan 2026-2030 (Raadzaal 07-01-2026 19:00)"
+              },
+              "content": 9895779
+            },
+            {
+              "meta_data": {
+                "reference_model": "agenda_item",
+                "label": "Informatiememo Wegenbeheerplan 2026-2030 (Raadzaal 21-01-2026 19:00)"
+              },
+              "content": 9945254
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "attachments": {
+        "document": [
+          {
+            "self": "api.notubiz.nl/document/16387544",
+            "url": "https://api.notubiz.nl/document/16387544/1",
+            "title": "SOK OMVV 2025 e250048157 (geanonimiseerd)",
+            "description": "",
+            "date": "",
+            "case_code": "",
+            "policy_field": "",
+            "category": "",
+            "id": 16387544,
+            "confidential": 0,
+            "publication_date": "2026-09-04",
+            "last_modified": "2025-12-16 08:30:48",
+            "version": 1,
+            "types": [
+              {
+                "id": 64,
+                "value": "Pdf"
+              }
+            ],
+            "versions": [
+              {
+                "type": "file",
+                "mime_type": "application/pdf",
+                "file_name": "SOK OMVV 2025 e250048157 (geanonimiseerd).pdf",
+                "file_size": 28980424,
+                "id": 1
+              }
+            ]
+          }
+        ]
+      },
+      "id": 1114625,
+      "creation_date": null,
+      "last_modified": "2025-12-16 08:30:48",
+      "confidential": 0,
+      "body": null,
+      "permission_group": "public",
+      "organisation_id": 1550,
+      "module_id": 1,
+      "attributes": [
+        {
+          "label": "Onderwerp",
+          "id": 1,
+          "datatype": "varchar",
+          "order": 4,
+          "multiple": 0,
+          "visible": "both",
+          "values": [
+            {
+              "meta_data": null,
+              "content": "371-25 Informatiememo SOK OMVV "
+            }
+          ]
+        },
+        {
+          "label": "Datum vergadering",
+          "id": 15,
+          "datatype": "datetime",
+          "order": 8,
+          "multiple": 0,
+          "visible": "both",
+          "values": [
+            {
+              "meta_data": null,
+              "content": "2025-12-17 00:00:00"
+            }
+          ]
+        },
+        {
+          "label": "Gekoppeld evenement",
+          "id": 54,
+          "datatype": "integer",
+          "order": 11,
+          "multiple": 1,
+          "visible": "detail",
+          "values": [
+            {
+              "meta_data": {
+                "reference_model": "agenda_item",
+                "label": "Lijst ingekomen stukken raad 17 december 2025 (Raadsvergadering  17-12-2025 19:30)"
+              },
+              "content": 9893143
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/motions.test.ts
+++ b/tests/motions.test.ts
@@ -216,8 +216,8 @@ Deno.test("motion list selection and the run window bound what gets fetched", ()
   assert(pattern.test("Moties"), "Moties matches");
   assert(pattern.test("1.2 Amendementen"), "numbered Amendementen matches");
   assert(pattern.test("Stemming"), "Stemming matches");
-  assert(!pattern.test("Toezeggingen"), "Toezeggingen is out of scope");
-  assert(!pattern.test("Ingekomen stukken"), "Ingekomen stukken is out of scope");
+  assert(!pattern.test("Toezeggingen"), "Toezeggingen is a register, not a motion list");
+  assert(!pattern.test("Ingekomen stukken"), "Ingekomen stukken is a register, not a motion list");
 
   const inWindow = ibabsExtractorTest.isEntryInWindow;
   assert(inWindow("2026-01-29T19:45:18.133", "2026-01-01", "2026-06-30"), "inside window");

--- a/tests/registers.test.ts
+++ b/tests/registers.test.ts
@@ -9,6 +9,10 @@ import {
 } from "../src/notubiz/motions.ts";
 import { getNotubizSource } from "../src/sources/index.ts";
 import type { NotubizModule, NotubizModuleItem } from "../src/types.ts";
+import { IbabsMeetingExtractor } from "../src/ibabs/extractor.ts";
+import { normalizeIbabsRegisterDocuments } from "../src/ibabs/normalize.ts";
+import { getIbabsSource } from "../src/sources/index.ts";
+import type { ExtractionIssue, IbabsList, IbabsListEntryBase } from "../src/types.ts";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -78,7 +82,11 @@ Deno.test("a register item's attachments become documents classified by the regi
   assertEquals(first.file_name, "Wegenbeheerplan 2026-2030 e250064948.pdf", "file name");
   assertEquals(first.size_in_bytes, 1630609, "size");
   assertEquals(first.content_type, "application/pdf", "mime type");
-  assertEquals(first.date_modified, "2026-02-05T10:51:47Z", "modification time, Dutch wall clock read as UTC");
+  assertEquals(
+    first.date_modified,
+    "2026-02-05T10:51:47Z",
+    "modification time, Dutch wall clock read as UTC",
+  );
   assertEquals(
     first.last_discussed_at,
     "2025-12-17T00:00:00Z",
@@ -179,4 +187,134 @@ Deno.test("motion attachments come from the attachment list, not from field 2", 
   assertEquals(documents.length, 1, "the attachment is materialised");
   assertEquals(documents[0].is_referenced_by, motion.id, "referenced by the motion");
   assertEquals(documents[0].classification, ["Moties"], "classified as the motion type");
+});
+
+// ---------------------------------------------------------------------------
+// iBabs registers
+// ---------------------------------------------------------------------------
+
+const INGEKOMEN: IbabsList = { ListId: "list-9", ListName: "Ingekomen stukken" };
+
+Deno.test("an iBabs register entry's documents are classified by the list", () => {
+  const source = getIbabsSource("utrecht");
+  const entry: IbabsListEntryBase = {
+    EntryId: "e-1",
+    EntryTitle: "Brief provincie over N201",
+    MutationDate: "2026-02-03T10:00:00",
+    ListId: INGEKOMEN.ListId,
+    ListName: INGEKOMEN.ListName,
+    ListCanVote: false,
+  };
+  const documents = normalizeIbabsRegisterDocuments(source, INGEKOMEN, entry, {
+    EntryId: "e-1",
+    Values: { Onderwerp: "Brief provincie over N201", "Datum ontvangst": "2026-02-01" },
+    Documents: [
+      {
+        Id: "d-1",
+        DisplayName: "Brief provincie",
+        FileName: "brief.pdf",
+        PublicDownloadURL: "https://api1.ibabs.eu/publicdownload.aspx?d=1",
+        FileSize: 1234,
+      },
+      { Id: "d-2", FileName: "bijlage.pdf", PublicDownloadURL: "https://api1.ibabs.eu/x?d=2" },
+    ],
+  });
+  assertEquals(documents.length, 2, "one document per attachment");
+  assertEquals(
+    documents[0].id,
+    "document:ibabs:gemeente:utrecht:d-1",
+    "same id scheme as meeting documents",
+  );
+  assertEquals(documents[0].classification, ["Ingekomen stukken"], "classified by the list");
+  assertEquals(documents[0].name, "Brief provincie", "display name");
+  assertEquals(documents[1].name, "bijlage.pdf", "file name when there is no display name");
+  assertEquals(documents[0].last_discussed_at, "2026-02-01T00:00:00Z", "dated by the entry's date");
+  assertEquals(
+    documents[0].is_referenced_by,
+    "organization:nl:gemeente:utrecht",
+    "the council, absent a meeting",
+  );
+  assertEquals(
+    documents[0].source_info.source_iri,
+    "ibabs://utrecht/listentry/e-1",
+    "the entry it came from",
+  );
+});
+
+class FakeIbabsRegisterClient {
+  votesCalls = 0;
+  downloads: string[] = [];
+
+  getMeetingTypes() {
+    return Promise.resolve([{ Id: "t1", Description: "Gemeenteraad" }]);
+  }
+  listMeetingsByDateRange() {
+    return Promise.resolve([]);
+  }
+  getLists() {
+    return Promise.resolve([
+      { ListId: "list-1", ListName: "Moties" },
+      { ListId: "list-9", ListName: "Ingekomen stukken" },
+    ]);
+  }
+  listListEntries(_source: unknown, listId: string) {
+    if (listId === "list-9") {
+      return Promise.resolve([
+        {
+          EntryId: "r-1",
+          EntryTitle: "Brief",
+          MutationDate: "2026-02-03T10:00:00",
+          ListId: "list-9",
+          ListName: "Ingekomen stukken",
+          ListCanVote: false,
+        },
+      ]);
+    }
+    return Promise.resolve([]);
+  }
+  getListEntry(_source: unknown, _listId: string, entryId: string) {
+    return Promise.resolve({
+      EntryId: entryId,
+      Values: { Onderwerp: "Brief provincie" },
+      Documents: [
+        { Id: "rd-1", FileName: "brief.pdf", PublicDownloadURL: "https://api1.ibabs.eu/x?d=rd-1" },
+      ],
+    });
+  }
+  getListEntryVotes() {
+    this.votesCalls += 1;
+    return Promise.resolve([]);
+  }
+  downloadDocument(document: { id: string }) {
+    this.downloads.push(document.id);
+    return Promise.reject(new Error("no network in tests"));
+  }
+}
+
+Deno.test("iBabs register entries reach the document path without a vote lookup", async () => {
+  const source = getIbabsSource("utrecht");
+  const client = new FakeIbabsRegisterClient();
+  const extractor = new IbabsMeetingExtractor(
+    // deno-lint-ignore no-explicit-any
+    client as any,
+    () => Promise.resolve(undefined),
+  );
+  const issues: ExtractionIssue[] = [];
+  const bundle = await extractor.extractForDateRange(source, "2026-02-01", "2026-02-28", {
+    onIssue: (issue) => {
+      issues.push(issue);
+    },
+  });
+
+  assertEquals(
+    client.downloads,
+    ["document:ibabs:gemeente:utrecht:rd-1"],
+    "the register document is fetched",
+  );
+  assertEquals(client.votesCalls, 0, "registers carry no votes, so none are asked for");
+  assertEquals(bundle.stats.motion_count ?? 0, 0, "a register entry is not a motion");
+  assert(
+    issues.some((issue) => issue.entity_id === "document:ibabs:gemeente:utrecht:rd-1"),
+    "the failed download is reported against the document",
+  );
 });

--- a/tests/registers.test.ts
+++ b/tests/registers.test.ts
@@ -1,0 +1,182 @@
+import { canonicalAgendaItemId } from "../src/ids.ts";
+import { MeetingIndex } from "../src/motions/normalize.ts";
+import {
+  isMotionModule,
+  isRegisterModule,
+  normalizeNotubizMotion,
+  normalizeNotubizMotionDocuments,
+  normalizeNotubizRegisterDocuments,
+} from "../src/notubiz/motions.ts";
+import { getNotubizSource } from "../src/sources/index.ts";
+import type { NotubizModule, NotubizModuleItem } from "../src/types.ts";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertEquals<T>(actual: T, expected: T, message: string): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+const fixture = (name: string) => Deno.readTextFile(new URL(`./fixtures/${name}`, import.meta.url));
+
+const INGEKOMEN_STUKKEN: NotubizModule = { id: 1, name: "Ingekomen stukken" };
+
+Deno.test("every module that is not a motion module is a register", async () => {
+  // Measured 2026-09-04 (#258): the documents ORI held for Ermelo in 2025 that
+  // we lacked sat in "Ingekomen stukken" and "Raadsvoorstellen", not under
+  // any agenda item. A register import that had to be told about each module
+  // by name would miss the next one an organisation adds.
+  const modules = JSON.parse(await fixture("notubiz_alkmaar_modules.json"))
+    .modules as NotubizModule[];
+  const registers = modules
+    .filter(isRegisterModule)
+    .map((m) => m.name)
+    .sort();
+  assertEquals(
+    registers,
+    [
+      "Bestuursdocumenten",
+      "Ingekomen stukken",
+      "Raadsvoorstellen",
+      "Schriftelijke vragen",
+      "Toezeggingen",
+    ],
+    "registers are every non-motion module",
+  );
+  assert(
+    modules.filter(isMotionModule).every((m) => !isRegisterModule(m)),
+    "disjoint",
+  );
+  assert(!isRegisterModule({ id: 9, name: "" }), "a nameless module is neither");
+});
+
+Deno.test("a register item's attachments become documents classified by the register", async () => {
+  const source = getNotubizSource("ermelo");
+  const items = JSON.parse(await fixture("notubiz_ermelo_ingekomen_stukken.json"))
+    .items as NotubizModuleItem[];
+
+  const documents = normalizeNotubizRegisterDocuments(source, INGEKOMEN_STUKKEN, items[0]);
+  assertEquals(documents.length, 7, "one document per attachment");
+
+  const first = documents[0];
+  assertEquals(first.id, "document:notubiz:gemeente:ermelo:16387622", "canonical document id");
+  assertEquals(first.type, "Document", "a plain document, no new entity type");
+  assertEquals(first.classification, ["Ingekomen stukken"], "classified by the register");
+  assertEquals(first.name, "Wegenbeheerplan 2026-2030 e250064948", "the attachment's own title");
+  assertEquals(
+    first.original_url,
+    "https://api.notubiz.nl/document/16387622/1",
+    "download URL as Notubiz gives it, version included",
+  );
+  assertEquals(first.file_name, "Wegenbeheerplan 2026-2030 e250064948.pdf", "file name");
+  assertEquals(first.size_in_bytes, 1630609, "size");
+  assertEquals(first.content_type, "application/pdf", "mime type");
+  assertEquals(first.date_modified, "2026-02-05T10:51:47Z", "modification time, Dutch wall clock read as UTC");
+  assertEquals(
+    first.last_discussed_at,
+    "2025-12-17T00:00:00Z",
+    "dated by the item's own date field",
+  );
+  assertEquals(
+    first.is_referenced_by,
+    "organization:nl:gemeente:ermelo",
+    "without a resolvable meeting the council is the parent",
+  );
+  assertEquals(
+    first.source_info.source_iri,
+    "https://api.notubiz.nl/modules/1/items/1114629",
+    "the register item it came from",
+  );
+
+  // The second attachment is at version 2: the URL and the cache key follow.
+  const second = documents[1];
+  assertEquals(second.original_url, "https://api.notubiz.nl/document/16504312/2", "versioned URL");
+  assertEquals((second.raw as { version: number }).version, 2, "version reaches the cache key");
+  assertEquals(second.file_name, "Vraag één-Ermelo.pdf", "file of the current version");
+});
+
+Deno.test("a register item linked to a known meeting is referenced by that meeting", async () => {
+  const source = getNotubizSource("ermelo");
+  const items = JSON.parse(await fixture("notubiz_ermelo_ingekomen_stukken.json"))
+    .items as NotubizModuleItem[];
+  const meetings = new MeetingIndex();
+  meetings.add({
+    id: "meeting:notubiz:gemeente:ermelo:m1",
+    type: "Meeting",
+    name: "Raadsvergadering",
+    classification: ["Agenda"],
+    start_date: "2025-12-17T19:00:00Z",
+    agenda: [{ id: canonicalAgendaItemId(source, 9893143), title: "Ingekomen stukken", order: 1 }],
+    source_info: {
+      supplier: "notubiz",
+      source: "ermelo",
+      organization_type: "gemeente",
+      canonical_id: "m1",
+      canonical_iri: "https://api.notubiz.nl/events/meetings/m1",
+    },
+    raw: {},
+  });
+
+  const documents = normalizeNotubizRegisterDocuments(
+    source,
+    INGEKOMEN_STUKKEN,
+    items[1],
+    meetings,
+  );
+  assertEquals(documents.length, 1, "one attachment");
+  assertEquals(
+    documents[0].is_referenced_by,
+    "meeting:notubiz:gemeente:ermelo:m1",
+    "parent meeting",
+  );
+  assertEquals(documents[0].last_discussed_at, "2025-12-17T19:00:00Z", "dated by the meeting");
+});
+
+Deno.test("a confidential attachment is not projected", () => {
+  const source = getNotubizSource("ermelo");
+  const item: NotubizModuleItem = {
+    id: 5,
+    attributes: [{ id: 1, label: "Onderwerp", values: [{ content: "Geheim stuk" }] }],
+    attachments: {
+      document: [
+        {
+          id: 100,
+          url: "https://api.notubiz.nl/document/100/1",
+          title: "Openbaar",
+          confidential: 0,
+        },
+        { id: 101, url: "https://api.notubiz.nl/document/101/1", title: "Geheim", confidential: 1 },
+      ],
+    },
+  };
+  const documents = normalizeNotubizRegisterDocuments(source, INGEKOMEN_STUKKEN, item);
+  assertEquals(
+    documents.map((d) => d.name),
+    ["Openbaar"],
+    "only the public one",
+  );
+  assertEquals(documents[0].id, "document:notubiz:gemeente:ermelo:100", "id");
+});
+
+Deno.test("motion attachments come from the attachment list, not from field 2", async () => {
+  // Field 2 carries the document under `value.document` with `meta_data: null`,
+  // so the old filter on `meta_data.reference_model` matched nothing and
+  // motions shipped without attachments. The attachment list is what Notubiz
+  // maintains, and it is what a register item carries too.
+  const source = getNotubizSource("ermelo");
+  const items = JSON.parse(await fixture("notubiz_ermelo_ingekomen_stukken.json"))
+    .items as NotubizModuleItem[];
+  const module: NotubizModule = { id: 6, name: "Moties" };
+  const motion = normalizeNotubizMotion(source, module, items[1]);
+  const documents = normalizeNotubizMotionDocuments(source, motion, items[1]);
+  assertEquals(documents.length, 1, "the attachment is materialised");
+  assertEquals(documents[0].is_referenced_by, motion.id, "referenced by the motion");
+  assertEquals(documents[0].classification, ["Moties"], "classified as the motion type");
+});

--- a/web/status_api.ts
+++ b/web/status_api.ts
@@ -1,4 +1,5 @@
 import type {
+  SourceCoverage,
   SourceStatus,
   SourceStatusState,
   StatusResponse,
@@ -7,7 +8,9 @@ import type {
   SupplierStatusState,
 } from "../src/types.ts";
 import {
+  type CoverageCheckRecord,
   getIngestStatus,
+  latestCoverageChecks,
   type SourceRunStatus,
   type SupplierRunWindow,
 } from "../src/ops/store.ts";
@@ -96,13 +99,17 @@ function latestTimestamp(values: Array<string | undefined>): string | undefined 
 export function buildStatusResponse(options: {
   runStatus: { sources: SourceRunStatus[]; supplierWindows: SupplierRunWindow[] };
   indexActivity: Map<string, SourceIndexActivity> | null;
+  coverageChecks?: CoverageCheckRecord[];
   now: number;
   windowHours: number;
 }): StatusResponse {
-  const { runStatus, indexActivity, now, windowHours } = options;
+  const { runStatus, indexActivity, coverageChecks, now, windowHours } = options;
   const runBySource = new Map(runStatus.sources.map((row) => [row.sourceKey, row]));
   const windowBySupplier = new Map(runStatus.supplierWindows.map((row) => [row.supplier, row]));
 
+  const coverageBySource = new Map(
+    (coverageChecks ?? []).map((check) => [check.source_key, toSourceCoverage(check)]),
+  );
   const sources: SourceStatus[] = listCatalogSources()
     .map((source) => {
       const run = runBySource.get(source.key);
@@ -138,6 +145,7 @@ export function buildStatusResponse(options: {
                 sourceKey: source.succeededBySourceKey,
               }
             : undefined,
+        coverage: coverageBySource.get(source.key),
       } satisfies SourceStatus;
     })
     .sort((left, right) => left.label.localeCompare(right.label, "nl"));
@@ -186,6 +194,24 @@ export function buildStatusResponse(options: {
 let cached: { value: StatusResponse; expiresAt: number } | null = null;
 let inFlight: Promise<StatusResponse> | null = null;
 
+function toSourceCoverage(check: CoverageCheckRecord): SourceCoverage {
+  return {
+    checkedAt: check.checked_at,
+    windowFrom: check.window_from,
+    windowTo: check.window_to,
+    supplierDocuments: check.supplier_documents,
+    heldDocuments: check.held_documents,
+    missingDocuments: check.missing_documents,
+    ratio:
+      check.supplier_documents > 0
+        ? Math.round((check.held_documents / check.supplier_documents) * 1000) / 1000
+        : 1,
+    lowerBound: check.warnings > 0,
+    missingSample: check.missing_sample,
+    error: check.error,
+  };
+}
+
 async function computeStatus(windowHours: number): Promise<StatusResponse> {
   const runStatus = await getIngestStatus(windowHours);
 
@@ -200,9 +226,20 @@ async function computeStatus(windowHours: number): Promise<StatusResponse> {
     console.warn(`[status] index activity unavailable, reporting imports only: ${message}`);
   }
 
+  // The coverage check is optional in the same way: absent until the weekly
+  // job has run, and never a reason for the endpoint to fail.
+  let coverageChecks: CoverageCheckRecord[] | undefined;
+  try {
+    coverageChecks = await latestCoverageChecks();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[status] coverage checks unavailable: ${message}`);
+  }
+
   return buildStatusResponse({
     runStatus,
     indexActivity,
+    coverageChecks,
     now: Date.now(),
     windowHours,
   });


### PR DESCRIPTION
Twee delen, samen het antwoord op #258 en #226: registers importeren, en meten of we compleet zijn.

## 1. Registers als documenten

**Wat er gemeten is.** Per Notubiz-documentnummer vergeleken met de oude ORI-index: tot en met 2024 hebben we vrijwel alles wat ORI heeft, voor 2025-2026 tien tot twintig procent (Ermelo 2025: 170 van 1.547). Van 40 ontbrekende Ermelo-stukken uit 2025 zaten er 24 in *Ingekomen stukken*, 11 in *Raadsvoorstellen* en 1 in *Moties*: registers, geen agendapunten. Notubiz-gemeentes publiceren sinds 2025 vrijwel alles zo; wij lazen alleen de module *Moties*. Bij iBabs hetzelfde met de lijsten (#226: 117.746 registeritems in ORI).

**Ontwerp.** Geen nieuw entiteitstype. Een registeritem wordt niet zelf geprojecteerd; zijn bijlagen worden `Document`-entiteiten met `classification: [<registernaam>]`, `is_referenced_by` de vergadering waar de agendaverwijzing naar oplost en anders de organisatie, gedateerd op de datum van het item. Geen schema-, mapping- of projectieversie-wijziging. Ze lopen door dezelfde download-, extractie- en BSN-controle als vergaderdocumenten.

- **Notubiz**: elke module die geen motiemodule is, is een register. Bijlagen komen uit `attachments.document` (bestandsnaam, grootte, mimetype, versie, wijzigingstijd; versie en wijzigingstijd bereiken de cache-sleutel). Dit repareert en passant de motie-import: die las alleen veld 2 en filterde op een `meta_data`-waarde die de echte payload nooit heeft, dus Notubiz-moties kwamen zonder één bijlage binnen. Vertrouwelijke bijlagen en niet-publieke items worden overgeslagen.
- **iBabs**: elke lijst die geen motielijst is, is een register; entries als bij moties, zonder stemmen-aanroep. Eigen cap `WOOZI_IBABS_REGISTER_LIMIT` (2000 per run).
- Een bestand dat twee keer in een run voorkomt wordt één keer opgehaald.

## 2. Aansluitcontrole

`scripts/coverage_check.ts` haalt per bron alle document-ids op die de leveranciers-API voor de laatste twaalf maanden toont (vergaderdocumenten en register-/motiebijlagen, via dezelfde clients en normalisers als de import, dus dezelfde ids) en vergelijkt die met het export-log. Wat de leverancier toont en wij missen is het gat: geteld, bemonsterd en opgeslagen in `coverage_check` in de ops-store. `/api/status` toont het per bron als `coverage` (supplier, held, missing, ratio, steekproef, `lowerBound` als er aanroepen faalden). Er wordt niets gedownload. Wekelijkse timer via `scripts/install-production-coverage.sh`, één bron tegelijk, gedeeld met de request-budgetten van de nachtelijke import.

**Tests**: 7 register-tests met een fixture uit Ermelo's echte *Ingekomen stukken*, 3 coverage-tests (vergelijking, Notubiz-listing met nepclient, store→status). Bestaande motie-, Notubiz-, iBabs- en status-tests groen.

**Na merge**: de dagelijkse import pikt registers op binnen zijn venster. Voor de achterstand is een backfill nodig (`full`-runs 2025-01-01 tot nu voor alle Notubiz- en iBabs-bronnen, naar schatting ruim honderdduizend nieuwe documenten door de extractie-vloot); volgorde en belasting stel ik voor in #258. Daarna de timer installeren en de eerste controle draaien.
