### PR TITLE
Give a search one total, whatever the sort

### DIFF
--- a/tests/search_api.test.ts
+++ b/tests/search_api.test.ts
@@ -1035,7 +1035,9 @@ Deno.test("a total is not inflated by rows that arrive mid-scan", async () => {
       const startOffset = Number(body.start_offset ?? 0);
       const maxHits = Number(body.max_hits);
       const count = Math.max(0, Math.min(maxHits, TOTAL_ROWS - startOffset));
-      const numHits = TOTAL_ROWS + round * growPerRound;
+      // The dedicated count request (max_hits 0, count_all) sees the index as
+      // it is; the growth simulates rows arriving between scan pages.
+      const numHits = body.count_all ? TOTAL_ROWS : TOTAL_ROWS + round * growPerRound;
       round += 1;
 
       const hits = Array.from({ length: count }, (_, index) => {
@@ -1202,4 +1204,74 @@ Deno.test("a snippet carries the highlight and nothing else", async () => {
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+Deno.test("the total does not move with the sort order", async () => {
+  // #265: the same query showed 146,881, 189,609 and 339,160 results under
+  // three sort orders. The numerator was a partial count and the denominator
+  // a collapse ratio sampled in whatever order the sort put first.
+  const originalFetch = globalThis.fetch;
+  const TOTAL_ROWS = 570_855;
+  const serve = async (_input: unknown, init?: unknown) => {
+    const body = JSON.parse(String((init as { body?: string } | undefined)?.body ?? "{}"));
+    if (body.count_all) {
+      return new Response(JSON.stringify({ num_hits: TOTAL_ROWS, hits: [] }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    // A sorted scan sees documents with many pages first (5 rows per result);
+    // relevance order collapses 2 to 1. Same index, different sample.
+    const perResult = body.sort_by ? 5 : 2;
+    const maxHits = Number(body.max_hits);
+    const startOffset = Number(body.start_offset ?? 0);
+    const hits = Array.from({ length: maxHits }, (_, index) => {
+      const row = startOffset + index;
+      const documentIndex = Math.floor(row / perResult);
+      return {
+        time: "2026-03-31T11:00:00Z",
+        entity_id: `document:notubiz:gemeente:ermelo:${documentIndex}#page=${(row % perResult) + 1}`,
+        parent_entity_id: `document:notubiz:gemeente:ermelo:${documentIndex}`,
+        page_number: (row % perResult) + 1,
+        entity_type: "DocumentPage",
+        name: `Schriftelijke vragen ${documentIndex}`,
+        start_date: "2025-01-14T17:00:00Z",
+        source_key: "ermelo",
+        content: "schriftelijke vragen over van alles",
+      };
+    });
+    // num_hits from a scan page is deliberately partial, as Quickwit's is
+    // without count_all.
+    return new Response(JSON.stringify({ num_hits: 4190, hits }), {
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    globalThis.fetch = serve as typeof globalThis.fetch;
+    await withV3Projection(async () => {
+      const totals: Record<string, number> = {};
+      for (const sort of ["relevance", "date_desc", "date_asc", "title_asc"]) {
+        const response = await searchMeetings({ query: "schriftelijke vragen", sort, limit: 24 });
+        assert(response.totalIsApproximate, `${sort}: a capped scan is an estimate`);
+        totals[sort] = response.totalCount ?? 0;
+      }
+      const distinct = new Set(Object.values(totals));
+      assert(distinct.size === 1, `one estimate for every sort, got ${JSON.stringify(totals)}`);
+      // 570,855 rows at 2 rows per result, rounded to three figures.
+      assert(
+        totals.relevance === 285_000,
+        `estimate from the exact count, got ${totals.relevance}`,
+      );
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("an estimate is rounded to three significant figures", async () => {
+  const { roundEstimate } = await import("../web/search_api.ts");
+  assert(roundEstimate(190_285) === 190_000, "190,285 -> 190,000");
+  assert(roundEstimate(146_881) === 147_000, "146,881 -> 147,000");
+  assert(roundEstimate(1_234) === 1_230, "1,234 -> 1,230");
+  assert(roundEstimate(999) === 999, "under a thousand stays exact");
 });

--- a/web/search_api.ts
+++ b/web/search_api.ts
@@ -730,6 +730,78 @@ function dedupeLatestIndexedHits(items: IndexedHit[]): IndexedHit[] {
   return [...byEntityId.values()].filter((item) => item.hit.op !== "delete");
 }
 
+/** Rows to sample when the ratio of rows to results has to be measured in an
+ * order the user did not choose. */
+const RATIO_SAMPLE_ROWS = 2000;
+
+/** Estimate how many results a capped scan would have produced.
+ *
+ * Two things made this number move (#265): the same query showed 146,881,
+ * 189,609 and 339,160 depending on the sort order.
+ *
+ * The numerator was Quickwit's `num_hits` from a scan page asked with
+ * `count_all: false`, which stops counting early: measured on the v4 index,
+ * 4,190 for an unsorted scan against 570,855 with a sort. So the numerator is
+ * now one dedicated count request, exact and cheap (0.2s on 570k rows).
+ *
+ * The denominator is how many index rows collapse into one result, and that
+ * depends on which rows a sort puts first: the newest documents carry more
+ * page rows than the oldest (measured 2.27 against 3.22 rows per result for
+ * the same query, newest-first against oldest-first). So the ratio is always
+ * taken from the relevance-ordered sample -- the scan itself when that is
+ * the order asked for, a separate sample otherwise -- and the same query gets
+ * the same estimate whatever the sort. It is still an estimate, rounded to
+ * three significant figures so it reads as one; the exact answer needs a
+ * distinct count over a fast field the index does not carry yet. */
+async function estimateTotal(
+  quickwit: QuickwitClient,
+  queryString: string,
+  sortBy: string | undefined,
+  scan: { scannedRows: number; scannedResults: number; fallbackRows: number },
+): Promise<number> {
+  let rows = scan.fallbackRows;
+  try {
+    const counted = await quickwit.searchRequest({
+      query: queryString,
+      max_hits: 0,
+      count_all: true,
+    });
+    rows = counted.num_hits;
+  } catch {
+    // The scan's own num_hits stays as the fallback; it is at least a number.
+  }
+
+  let ratio = scan.scannedResults > 0 ? scan.scannedRows / scan.scannedResults : 1;
+  if (sortBy) {
+    try {
+      const sample = await quickwit.searchRequest({
+        query: queryString,
+        max_hits: RATIO_SAMPLE_ROWS,
+        count_all: false,
+      });
+      const hits = sample.hits as SearchHit[];
+      const distinct = new Set(hits.map((hit) => searchResultEntityId(hit)));
+      if (distinct.size > 0) {
+        ratio = hits.length / distinct.size;
+      }
+    } catch {
+      // Keep the scan's own ratio; a sort-dependent estimate beats none.
+    }
+  }
+
+  return roundEstimate(rows / Math.max(ratio, 1));
+}
+
+/** Three significant figures above a thousand: 190,285 reads as exact and is
+ * not; 190,000 reads as what it is. */
+export function roundEstimate(value: number): number {
+  if (value < 1000) {
+    return Math.round(value);
+  }
+  const magnitude = 10 ** (Math.floor(Math.log10(value)) - 2);
+  return Math.round(value / magnitude) * magnitude;
+}
+
 /** A hit is presented as the thing a reader wants to open, which is not always
  * the thing that matched: a page belongs to its document, and a transcript
  * belongs to its meeting — that is where the player and the spoken text are. */
@@ -1031,9 +1103,17 @@ async function collectSearchWindow(
   // same switch #184, #192 and #194 are waiting on.
   const groupedCount = sortedResults.length;
   const scannedEverything = exhausted && !scanLimitReached;
-  const totalCount = scannedEverything
-    ? groupedCount
-    : Math.max(groupedCount, Math.round((rawNumHits ?? 0) / Math.max(rowsPerResult, 1)));
+  let totalCount = groupedCount;
+  if (!scannedEverything) {
+    totalCount = Math.max(
+      groupedCount,
+      await estimateTotal(quickwit, queryString, sortBy, {
+        scannedRows: rawSeen,
+        scannedResults: collected.size,
+        fallbackRows: rawNumHits ?? 0,
+      }),
+    );
+  }
 
   return {
     results: pageWindowResults,


### PR DESCRIPTION
Dezelfde zoekopdracht gaf 146.881, 189.609 en 339.160 resultaten onder drie sorteringen (#265). Twee dingen bewogen mee.

**De teller** was Quickwit's `num_hits` van een scanpagina met `count_all: false`, en die stopt vroeg met tellen: gemeten op v4 4.190 zonder sortering tegen 570.855 mét. Hij komt nu uit één aparte telaanroep, exact en goedkoop (0,2 s op 570k rijen).

**De noemer** is hoeveel indexrijen in één resultaat samenvallen, en dat hangt af van welke rijen de sortering vooraan zet: de nieuwste documenten dragen meer paginarijen dan de oudste (2,27 tegen 3,22 rijen per resultaat voor dezelfde query). De verhouding komt nu altijd uit de relevantie-volgorde: de scan zelf als daarop gesorteerd wordt, anders een aparte steekproef van 2.000 rijen. Elke sortering krijgt zo dezelfde schatting.

Het blijft een schatting en wordt daarom op drie cijfers afgerond zodat het als schatting leest (#263): 190.000, niet 190.285. De pagina zei al "ongeveer". Een exact aantal vraagt om een distinct-telling op een fast field dat de index nog niet heeft.

Tests: één schatting voor vier sorteringen op dezelfde stub-index, afronding, en de bestaande "rijen die tijdens de scan bijkomen"-test aangepast zodat alleen scanpagina's groeien.

Closes #265. Closes #263.