### PR TITLE
Install pnpm from a pin, not from corepack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,13 +55,21 @@ jobs:
       - name: Check out
         uses: actions/checkout@v5
 
+      # pnpm comes from its own action, not from corepack: corepack downloads
+      # pnpm on every run and that download tripped an undici assertion in
+      # Node 24 ("assert(!this.paused)"), failing the job before a single
+      # test ran. The version is pinned by package.json's packageManager.
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: pnpm
 
       - name: Install
-        run: corepack enable && pnpm install --frozen-lockfile --config.strict-dep-builds=false
+        run: pnpm install --frozen-lockfile --config.strict-dep-builds=false
 
       - name: Build the front end
         run: pnpm run build:web

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -5,7 +5,8 @@ WORKDIR /app
 ENV PNPM_CONFIG_STRICT_DEP_BUILDS=false
 
 COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable && pnpm install --frozen-lockfile --config.strict-dep-builds=false
+# Pinned pnpm from npm rather than corepack: see .github/workflows/test.yml.
+RUN npm install -g pnpm@11.7.0 && pnpm install --frozen-lockfile --config.strict-dep-builds=false
 
 COPY tsconfig.json vite.config.ts ./
 COPY web ./web

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "woozi",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "web": "pnpm run build:web && deno run -A web/server.ts",
     "serve:web": "deno run -A web/server.ts",


### PR DESCRIPTION
De web-job in CI begon met `corepack enable`, dat bij elke run de nieuwste pnpm downloadt. Vandaag struikelde die download over een assertion in undici van Node 24 (`assert(!this.paused)`) en de job stierf voor er één test draaide. De image-build deed hetzelfde en stond één wankele download van dezelfde fout.

`package.json` pint nu `pnpm@11.7.0` in `packageManager` (de lokale versie; lockfile 9.0). CI installeert hem via `pnpm/action-setup`, dat die pin leest, en cachet de store via `setup-node`. De Dockerfile installeert dezelfde versie uit npm. De web-build-stage is met deze wijziging lokaal gebouwd en leverde `web/dist` op.