### PR TITLE
Count a run's issues through an index

### DIFF
--- a/src/ops/store.ts
+++ b/src/ops/store.ts
@@ -160,6 +160,14 @@ async function getDatabase(): Promise<DatabaseSync> {
         `CREATE INDEX IF NOT EXISTS ingest_run_mode_source_started
          ON ingest_run(execution_mode, source_key, started_at DESC)`,
       );
+      // ingest_run_issue is counted per run on every progress update
+      // (`issue_count = (SELECT COUNT(*) ... WHERE run_id = @id)`). Without an
+      // index that is a scan of the whole table, and the table is large: 2.1M
+      // rows, 774 MB, on 2026-09-05. Measured that day, every worker sat at 100%
+      // CPU reading 500 MB of this table per meeting it imported, and the
+      // register backfill crawled at a few documents a minute. The index took 6
+      // seconds to build on production and the CPU fell to nothing.
+      db.exec(`CREATE INDEX IF NOT EXISTS ingest_run_issue_run ON ingest_run_issue (run_id)`);
       return db;
     })();
   }


### PR DESCRIPTION
`ingest_run_issue` wordt per run geteld bij elke voortgangsupdate (de subquery die `issue_count` bijwerkt). De tabel had geen index op `run_id` en is niet klein: 2,1 miljoen rijen, 774 MB, vooral thumbnail-waarschuwingen. Elke worker zat daardoor op 100% CPU en las per geïmporteerde vergadering een halve gigabyte van die tabel; de register-backfill van vandaag kroop met een paar documenten per minuut terwijl de machine druk leek.

De index is op productie in zes seconden gebouwd (`CREATE INDEX IF NOT EXISTS`, dus deze PR is daar idempotent) en de CPU van de workers viel terug naar nul. Het schema maakt hem nu voor elke database aan.

Losse observatie voor later: 2,1 miljoen meldingen, waarvan het merendeel `PDF thumbnail prewarm failed`, is opslag zonder lezer. Opruimen of niet meer loggen is een apart besluit.