### PR TITLE
Judge a claim by when it was made, not by when it was queued

### DIFF
--- a/src/ops/store.ts
+++ b/src/ops/store.ts
@@ -143,6 +143,11 @@ async function getDatabase(): Promise<DatabaseSync> {
         // Column already exists on initialized databases.
       }
       try {
+        db.exec("ALTER TABLE ingest_run ADD COLUMN claimed_at TEXT");
+      } catch {
+        // Column already exists on initialized databases.
+      }
+      try {
         db.exec("ALTER TABLE ingest_run ADD COLUMN motion_count INTEGER NOT NULL DEFAULT 0");
       } catch {
         // Column already exists on initialized databases.
@@ -490,8 +495,15 @@ const MAX_INTERRUPTED_REQUEUES = 5;
  * two worker replicas restarting seconds apart (a deploy), the second one to
  * boot would otherwise requeue rows its sibling just claimed, and the same
  * run ends up executing twice concurrently (seen July 2026: duplicate
- * failures and phantom stalls for the same run id). Genuinely interrupted
- * rows carry a started_at from before the restart, well past this margin. */
+ * failures and phantom stalls for the same run id).
+ *
+ * The age is that of the claim, `claimed_at`, not of the row. `started_at` is
+ * set when the run is enqueued, and a backfill chunk can sit in the queue for
+ * hours before a worker takes it; judged by `started_at` such a claim looked
+ * ancient the moment it was made. Seen 2026-09-05: after a restart three of
+ * four workers each requeued and re-claimed the same eight runs within one
+ * second, and executed them in triplicate for an hour. Rows claimed before
+ * this column existed carry no `claimed_at` and fall back to `started_at`. */
 const RECONCILE_MIN_CLAIM_AGE_MS = 120_000;
 
 export async function reconcileInterruptedRuns(): Promise<IngestRunRecord[]> {
@@ -505,7 +517,7 @@ export async function reconcileInterruptedRuns(): Promise<IngestRunRecord[]> {
         started_at, finished_at, meeting_count, document_count, cache_hits, downloaded_count, motion_count, recording_count,
         issue_count, quickwit_index_id, error_message, interrupted_count
        FROM ingest_run
-       WHERE status = 'running' AND started_at < ?
+       WHERE status = 'running' AND COALESCE(claimed_at, started_at) < ?
        ORDER BY started_at ASC`,
     )
     .all(claimedBefore) as unknown as (RunRow & { interrupted_count: number | null })[];
@@ -613,19 +625,23 @@ export async function reconcileInterruptedRuns(): Promise<IngestRunRecord[]> {
 // Atomically move a queued run to "running". Multiple workers can race on
 // the same queued id; only one succeeds. The loser gets null and must try
 // another run. Requires SQLite >= 3.35 for UPDATE ... RETURNING.
+/** Take a queued run for this process. Atomic: the status guard in the
+ * UPDATE means at most one caller gets the row back. The claim is stamped so
+ * a sibling's startup reconcile can tell a run that is being worked on from
+ * one whose worker died (see RECONCILE_MIN_CLAIM_AGE_MS). */
 export async function claimQueuedRun(runId: string): Promise<IngestRunRecord | null> {
   const db = await getDatabase();
   const row = db
     .prepare(
       `UPDATE ingest_run
-       SET status = 'running', error_message = NULL
+       SET status = 'running', error_message = NULL, claimed_at = @claimed_at
        WHERE id = @id AND status = 'queued'
        RETURNING id, source_key, supplier, date_from, date_to, trigger_mode as trigger,
          execution_mode, parent_run_id, projection_version, derivation_version, status,
          started_at, finished_at, meeting_count, document_count, cache_hits, motion_count,
          recording_count, downloaded_count, issue_count, quickwit_index_id, error_message`,
     )
-    .get({ id: runId }) as IngestRunRecord | undefined;
+    .get({ id: runId, claimed_at: new Date().toISOString() }) as IngestRunRecord | undefined;
   return row ? normalizeRunRecord(row) : null;
 }
 

--- a/tests/ops_reconcile.test.ts
+++ b/tests/ops_reconcile.test.ts
@@ -28,6 +28,21 @@ function assertEquals(actual: unknown, expected: unknown, message: string): void
 function backdateRunStart(runId: string, minutes = 10): void {
   const db = new DatabaseSync(Deno.env.get("WOOZI_KV_PATH")!);
   try {
+    db.prepare(`UPDATE ingest_run SET started_at = ?, claimed_at = ? WHERE id = ?`).run(
+      new Date(Date.now() - minutes * 60_000).toISOString(),
+      new Date(Date.now() - minutes * 60_000).toISOString(),
+      runId,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/** A run that sat in the queue for a while: enqueued long ago, claimed now
+ * (or not yet). */
+function backdateEnqueue(runId: string, minutes = 300): void {
+  const db = new DatabaseSync(Deno.env.get("WOOZI_KV_PATH")!);
+  try {
     db.prepare(`UPDATE ingest_run SET started_at = ? WHERE id = ?`).run(
       new Date(Date.now() - minutes * 60_000).toISOString(),
       runId,
@@ -67,7 +82,10 @@ Deno.test("interrupted runs are requeued instead of failed, up to the cap", asyn
 
   // Restarts two through five: requeued again.
   for (let interruption = 2; interruption <= 5; interruption += 1) {
-    assert(await claimQueuedRun(runId), `requeued run can be claimed (interruption ${interruption})`);
+    assert(
+      await claimQueuedRun(runId),
+      `requeued run can be claimed (interruption ${interruption})`,
+    );
     backdateRunStart(runId);
     reconciled = await reconcileInterruptedRuns();
     target = reconciled.find((run) => run.id === runId);
@@ -140,5 +158,67 @@ Deno.test("reconcile leaves freshly claimed runs to their owning worker", async 
   assert(
     !reconciled.some((item) => item.id === run.id),
     "a fresh claim must not be requeued by a booting sibling",
+  );
+});
+
+Deno.test("a run that queued for hours and was just claimed is not requeued", async () => {
+  // 2026-09-05: a backfill of 1,172 chunks was enqueued at 07:18 and the
+  // workers restarted at 12:22. Judged by started_at every fresh claim was
+  // five hours old, so each booting worker requeued its siblings' claims and
+  // took them itself; eight runs ran in triplicate.
+  const run = await createRun({
+    source_key: "almelo",
+    supplier: "ibabs",
+    date_from: "2025-09-05",
+    date_to: "2026-03-05",
+    trigger: "scheduled",
+    execution_mode: "full",
+    parent_run_id: undefined,
+    projection_version: "test",
+    derivation_version: "test",
+    status: "queued",
+  });
+  backdateEnqueue(run.id);
+  assert(await claimQueuedRun(run.id), "run can be claimed");
+
+  const reconciled = await reconcileInterruptedRuns();
+  assert(
+    !reconciled.some((item) => item.id === run.id),
+    "a claim made seconds ago belongs to a live worker, however old the row",
+  );
+  const details = await getRunDetails(run.id);
+  assertEquals(details?.run.status, "running", "the owning worker keeps its run");
+});
+
+Deno.test("a run claimed before claimed_at existed is judged by started_at", async () => {
+  const run = await createRun({
+    source_key: "soest",
+    supplier: "notubiz",
+    date_from: "2024-01-01",
+    date_to: "2024-12-31",
+    trigger: "scheduled",
+    execution_mode: "full",
+    parent_run_id: undefined,
+    projection_version: "test",
+    derivation_version: "test",
+    status: "queued",
+  });
+  assert(await claimQueuedRun(run.id), "run can be claimed");
+  // As left by a worker running the previous schema: an old row, no stamp.
+  const db = new DatabaseSync(Deno.env.get("WOOZI_KV_PATH")!);
+  try {
+    db.prepare(`UPDATE ingest_run SET started_at = ?, claimed_at = NULL WHERE id = ?`).run(
+      new Date(Date.now() - 10 * 60_000).toISOString(),
+      run.id,
+    );
+  } finally {
+    db.close();
+  }
+
+  const reconciled = await reconcileInterruptedRuns();
+  assertEquals(
+    reconciled.find((item) => item.id === run.id)?.status,
+    "queued",
+    "an unstamped old running row is still treated as interrupted",
   );
 });


### PR DESCRIPTION
Reconcile skips runs claimed in the last two minutes so a worker that boots seconds after its sibling does not requeue what the sibling just claimed. It measured that age with `started_at`, which is set when the run is **enqueued**. A backfill chunk queued at 07:18 and claimed at 12:22 was five hours old at the moment of its claim.

Seen on production today (2026-09-05, after the 12:22 worker restart): three of four workers each requeued and re-claimed the same eight runs within one second and executed them in triplicate for over an hour, all on the one iBabs per-IP budget. Half the fleet's slots were duplicates.

- `claimQueuedRun` stamps `claimed_at` (new nullable column, added like the others).
- `reconcileInterruptedRuns` judges `COALESCE(claimed_at, started_at)`; rows claimed under the old schema still reconcile by `started_at`.
- Tests: the queued-for-hours case (fails on main), and the unstamped-old-row fallback.

No deploy is needed for the running backfill to benefit until the next restart; the point is that the next restart (this deploy included) no longer triplicates.