### PR TITLE
Let the coverage check take one worker's share of iBabs, after the night

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -96,6 +96,19 @@ services:
       S3_STORAGE_REGION: ${S3_STORAGE_REGION}
       WOOZI_EXTRACTION_SERVICE_URL: ${WOOZI_EXTRACTION_SERVICE_URL:-}
       WOOZI_SCHEDULER_ENABLED: ${WOOZI_SCHEDULER_ENABLED:-1}
+      # The weekly coverage check (scripts/coverage_check.ts) runs in this
+      # container and talks to iBabs from the same address as the workers.
+      # Without these it paced itself as if it were alone on the address
+      # (2026-09-06: iBabs' edge answered 403 "The request is blocked" within
+      # minutes, to the check and to the backfill workers alike). Same values
+      # as the worker service: this process takes one worker's share and
+      # trips the same breaker file.
+      WOOZI_IBABS_WORKERS: ${WOOZI_WORKER_REPLICAS:-1}
+      WOOZI_IBABS_SOAP_PER_MINUTE: ${WOOZI_IBABS_SOAP_PER_MINUTE:-180}
+      WOOZI_IBABS_DOWNLOAD_PER_MINUTE: ${WOOZI_IBABS_DOWNLOAD_PER_MINUTE:-30}
+      WOOZI_IBABS_COOLDOWN_MS: ${WOOZI_IBABS_COOLDOWN_MS:-60000}
+      WOOZI_IBABS_THROTTLE_BASE_MS: ${WOOZI_IBABS_THROTTLE_BASE_MS:-3000}
+      WOOZI_IBABS_BREAKER_PATH: /data/ibabs-breaker.json
       OTEL_DENO: ${OTEL_DENO:-true}
       OTEL_SERVICE_NAME: woozi-web
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318

--- a/scripts/coverage_check.ts
+++ b/scripts/coverage_check.ts
@@ -16,12 +16,21 @@
  *
  * Runs weekly on production from a systemd timer
  * (scripts/install-production-coverage.sh). It shares the suppliers' request
- * budgets with the nightly import -- iBabs is paced by the same fleet-wide
- * limiter -- which is why it runs on a quiet morning and one source at a
- * time.
+ * budgets with the import workers: iBabs is paced by the same per-address
+ * limiter, and this process takes one worker's share of it (the compose
+ * file gives the web container the same WOOZI_IBABS_* settings as the
+ * workers), which is why it runs one source at a time, after the nightly
+ * imports are done, and takes hours.
+ *
+ * When iBabs' edge nonetheless answers 403 "The request is blocked", the
+ * check waits and tries the source once more before recording it as
+ * failed. The first run (2026-09-06, unpaced) saw that block lift within
+ * minutes of the burst stopping; a block that outlasts the wait is the
+ * address-level kind and a person has to deal with it.
  */
 import { parseArgs } from "node:util";
 import { compareCoverage, listSupplierDocuments } from "../src/coverage/check.ts";
+import { IbabsBlockedError } from "../src/ibabs/client.ts";
 import { getExportLog } from "../src/exports/log.ts";
 import { recordCoverageCheck } from "../src/ops/store.ts";
 import { listRunnableCatalogSources, listSources } from "../src/sources/index.ts";
@@ -71,13 +80,38 @@ console.log(
   }`,
 );
 
+/** How long to stay off iBabs after its edge blocks a request, before the
+ * source is listed once more. */
+const BLOCKED_RETRY_DELAY_MS = Number(
+  Deno.env.get("WOOZI_COVERAGE_BLOCKED_RETRY_MS") ?? 5 * 60_000,
+);
+
+async function listWithOneRetryWhenBlocked(
+  source: (typeof sources)[number],
+): Promise<Awaited<ReturnType<typeof listSupplierDocuments>>> {
+  try {
+    return await listSupplierDocuments(source, windowFrom, windowTo);
+  } catch (error) {
+    if (!(error instanceof IbabsBlockedError)) {
+      throw error;
+    }
+    console.log(
+      `${source.key.padEnd(26)} blocked by iBabs' edge; waiting ${Math.round(
+        BLOCKED_RETRY_DELAY_MS / 1000,
+      )}s before one more attempt`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, BLOCKED_RETRY_DELAY_MS));
+    return await listSupplierDocuments(source, windowFrom, windowTo);
+  }
+}
+
 let checked = 0;
 let failed = 0;
 for (const source of sources) {
   const started = performance.now();
   const checkedAt = new Date().toISOString();
   try {
-    const listing = await listSupplierDocuments(source, windowFrom, windowTo);
+    const listing = await listWithOneRetryWhenBlocked(source);
     const held = exportLog.listEntityIds(source.key, "document:");
     const comparison = compareCoverage(listing.documentIds, held);
     const ratio =

--- a/scripts/install-production-coverage.sh
+++ b/scripts/install-production-coverage.sh
@@ -3,13 +3,19 @@
 # that runs scripts/coverage_check.ts inside the web container and stores the
 # result in the ops database, where /api/status reads it.
 #
-# Usage: DEPLOY_HOST=root@host WOOZI_COVERAGE_DAY=Sun WOOZI_COVERAGE_TIME=05:00 \
+# Usage: DEPLOY_HOST=root@host WOOZI_COVERAGE_DAY=Sun WOOZI_COVERAGE_TIME=08:00 \
 #        bash scripts/install-production-coverage.sh
+#
+# The check shares the iBabs per-address budget with the workers, paced at
+# one worker's share, so it takes hours and must not overlap the nightly
+# imports (00:00 until about 08:00): the first run, at 05:00, pushed the
+# address over budget within minutes and iBabs blocked imports and check
+# alike. Re-run this script after changing the time; a deploy does not.
 set -euo pipefail
 
 DEPLOY_HOST="${DEPLOY_HOST:-root@91.98.32.151}"
 COVERAGE_DAY="${WOOZI_COVERAGE_DAY:-Sun}"
-COVERAGE_TIME="${WOOZI_COVERAGE_TIME:-05:00}"
+COVERAGE_TIME="${WOOZI_COVERAGE_TIME:-08:00}"
 COVERAGE_MONTHS="${WOOZI_COVERAGE_MONTHS:-12}"
 
 ssh "$DEPLOY_HOST" "COVERAGE_DAY='$COVERAGE_DAY' COVERAGE_TIME='$COVERAGE_TIME' COVERAGE_MONTHS='$COVERAGE_MONTHS' bash -s" <<'REMOTE'


### PR DESCRIPTION
The weekly coverage check runs inside the web container, which had none of the iBabs pacing settings. It paced itself as if it were alone on the address while the four workers already used the whole per-IP budget.

Its first run (Sunday 2026-09-06 05:00, during the register backfill) pushed the address over budget within minutes. iBabs' edge answered 403 "The request is blocked" to the check **and** to the backfill workers: the check failed Almelo, Ameland and Leiderdorp outright and two backfill windows (Oldebroek, Ooststellingwerf) failed with the same error. I stopped the check at 05:55; the block lifted as soon as the burst stopped.

- `docker-compose.production.yml`: the web service gets the same `WOOZI_IBABS_*` settings as the workers, so the check takes one worker's share and trips the shared breaker file.
- `scripts/install-production-coverage.sh`: default time 08:00, after the nightly imports. **Re-run the installer after merging**, a deploy does not touch the timer.
- `scripts/coverage_check.ts`: a blocked answer earns one five-minute wait and a second attempt before the source is recorded as failed.

At one worker's share (36 SOAP calls per minute) the check takes hours; it is a weekly Sunday job, that is fine.