### PR TITLE
Download a Notubiz document as its current version, not as /1

### DIFF
--- a/scripts/revalidate_documents.ts
+++ b/scripts/revalidate_documents.ts
@@ -31,7 +31,7 @@
 // transfer as-is):
 //   - iBabs (PublicDownloadURL, same publicdownload.aspx endpoint as ori3):
 //     HTTP 403 or 404 = gone. HTTP 200 = live. Anything else = unknown.
-//   - Notubiz (canonicalDocumentDownloadUrl, api.notubiz.nl/document/{id}/1):
+//   - Notubiz (canonicalDocumentDownloadUrl, api.notubiz.nl/document/{id}/{version}):
 //     HTTP 400 with an XML body containing "<error_code>" = gone (observed
 //     message: "Document kan niet gedownload worden"). HTTP 200 = live.
 //     Anything else (including a bare 404, which this endpoint does not use)
@@ -185,7 +185,12 @@ async function runSweep(supplier: string, limit: number): Promise<void> {
   const batch: DocumentHit[] = [];
   let offset = startOffset;
   while (batch.length < limit) {
-    const page = await fetchBatch(quickwit, supplier, offset, Math.min(QUICKWIT_PAGE_SIZE, limit - batch.length));
+    const page = await fetchBatch(
+      quickwit,
+      supplier,
+      offset,
+      Math.min(QUICKWIT_PAGE_SIZE, limit - batch.length),
+    );
     if (page.length === 0) {
       break;
     }
@@ -197,7 +202,9 @@ async function runSweep(supplier: string, limit: number): Promise<void> {
   }
 
   if (batch.length === 0) {
-    console.log(`no more ${supplier} documents after offset ${startOffset} -- wrapping cursor to 0`);
+    console.log(
+      `no more ${supplier} documents after offset ${startOffset} -- wrapping cursor to 0`,
+    );
     await setRevalidationCursor(supplier, 0);
     return;
   }
@@ -248,13 +255,7 @@ async function runSweep(supplier: string, limit: number): Promise<void> {
   }
 
   for (const { hit, status } of toRecord) {
-    await recordRevalidationResult(
-      hit.entityId,
-      supplier,
-      hit.sourceKey,
-      status,
-      hit.url ?? null,
-    );
+    await recordRevalidationResult(hit.entityId, supplier, hit.sourceKey, status, hit.url ?? null);
   }
 
   await setRevalidationCursor(supplier, offset);

--- a/src/notubiz/normalize.ts
+++ b/src/notubiz/normalize.ts
@@ -48,8 +48,38 @@ function collectAttachmentIds(
   return [...new Set(result)];
 }
 
-function canonicalDocumentDownloadUrl(documentId: string): string {
-  return `https://api.notubiz.nl/document/${documentId}/1`;
+/** The download URL of the document's current version.
+ *
+ * Notubiz keeps every uploaded version under `document/{id}/{n}`. When a
+ * municipality uploads a new one -- typically an anonymised copy -- the
+ * earlier versions go behind a token and answer 400 "U moet een token
+ * doorgeven", while the new one is public. This always pointed at `/1`, so
+ * for every document revised after publication we handed re-users a dead
+ * link and kept the pre-anonymisation text (#269: 75 of 156 sampled recent
+ * documents). The payload names the current version twice: `url` carries
+ * the full download URL and `version` the number; the first is used when it
+ * is an API download URL, the second otherwise, `/1` only when the payload
+ * says nothing. The version is part of the cache key, so a revised document
+ * is downloaded and extracted again. */
+function canonicalDocumentDownloadUrl(
+  documentId: string,
+  document: Record<string, unknown> = {},
+): string {
+  if (
+    typeof document.url === "string" &&
+    /^https?:\/\/api\.notubiz\.nl\/document\/\d+\/\d+$/.test(document.url.trim())
+  ) {
+    return document.url.trim().replace(/^http:/, "https:");
+  }
+  const version =
+    typeof document.version === "number" &&
+    Number.isInteger(document.version) &&
+    document.version > 0
+      ? document.version
+      : typeof document.version === "string" && /^\d+$/.test(document.version)
+        ? Number(document.version)
+        : 1;
+  return `https://api.notubiz.nl/document/${documentId}/${version}`;
 }
 
 function agendaAttributeValue(
@@ -87,7 +117,7 @@ function normalizeAgendaDocumentLink(
         : (normalizeFileName(document) ?? `Document ${documentId}`),
     file_name: normalizeFileName(document),
     content_type: normalizeContentType(document),
-    original_url: canonicalDocumentDownloadUrl(documentId),
+    original_url: canonicalDocumentDownloadUrl(documentId, document),
   };
 }
 
@@ -341,7 +371,7 @@ export function normalizeNotubizDocuments(
     // The supplier payload sometimes includes municipality-hosted document URLs that return 4xx
     // even though the document metadata itself is valid. Use the stable API download endpoint
     // for retrieval and keep the original source URL only as metadata.
-    original_url: canonicalDocumentDownloadUrl(documentId),
+    original_url: canonicalDocumentDownloadUrl(documentId, document),
     identifier_url:
       typeof document.self === "string"
         ? `https://${document.self.replace(/^https?:\/\//, "")}`

--- a/tests/notubiz_normalize.test.ts
+++ b/tests/notubiz_normalize.test.ts
@@ -95,3 +95,63 @@ Deno.test("meeting responses without a meeting are described, not swallowed", as
   const empty = describeMeetingResponseError({});
   assert(empty === "no error detail in response", `got ${empty}`);
 });
+
+Deno.test("a revised document downloads as its current version, not as /1", async () => {
+  // #269: Notubiz keeps every version under document/{id}/{n}. Once a
+  // municipality uploads an anonymised copy, /1 goes behind a token and
+  // answers 400; the new version is the public one. The payload says which
+  // version is current, twice.
+  const source = getNotubizSource("haarlem");
+  const attributes = JSON.parse(
+    await Deno.readTextFile(new URL("./fixtures/notubiz_haarlem_attributes.json", import.meta.url)),
+  ) as NotubizOrganizationAttributes;
+  const rawMeeting = JSON.parse(
+    await Deno.readTextFile(new URL("./fixtures/notubiz_haarlem_meeting.json", import.meta.url)),
+  );
+
+  const revised: Record<string, unknown>[] = [];
+  const walk = (node: unknown) => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+    } else if (node && typeof node === "object") {
+      const record = node as Record<string, unknown>;
+      if (Array.isArray(record.versions) && typeof record.id === "number") {
+        revised.push(record);
+      }
+      Object.values(record).forEach(walk);
+    }
+  };
+  walk(rawMeeting);
+  assert(revised.length === 2, "the fixture carries two documents");
+
+  // Document 42, as the live API shapes a thrice-uploaded document: url and
+  // version both name /3, versions listed newest first.
+  revised[0].version = 3;
+  revised[0].url = "https://api.notubiz.nl/document/42/3";
+  revised[0].versions = [{ id: 3 }, { id: 2 }, { id: 1 }].map((item) => ({
+    ...item,
+    mime_type: "application/pdf",
+    file_name: "memo-participatie-geanonimiseerd.pdf",
+  }));
+  // Document 43: only the version number, no url.
+  revised[1].version = 2;
+  delete revised[1].url;
+
+  const meeting = normalizeNotubizMeeting(source, attributes, rawMeeting);
+  const documents = normalizeNotubizDocuments(source, meeting);
+  const byId = new Map(documents.map((document) => [document.id, document]));
+  assert(
+    byId.get("document:notubiz:gemeente:haarlem:42")?.original_url ===
+      "https://api.notubiz.nl/document/42/3",
+    "the payload's url names the current version",
+  );
+  assert(
+    byId.get("document:notubiz:gemeente:haarlem:43")?.original_url ===
+      "https://api.notubiz.nl/document/43/2",
+    "without a url the version number does",
+  );
+  assert(
+    meeting.agenda?.[0]?.documents?.every((link) => !link.original_url?.endsWith("/1")) ?? true,
+    "agenda document links follow the same rule",
+  );
+});


### PR DESCRIPTION
Fixes #269.

Notubiz keeps every uploaded version under `document/{id}/{n}`. When a municipality uploads a new one, typically an anonymised copy, the earlier versions go behind a token and answer 400 "U moet een token doorgeven"; the new one is public. Meeting documents always pointed at `/1`, so for every document revised after publication we handed re-users a dead link and kept the pre-anonymisation text (75 of 156 sampled recent documents in the report).

The payload names the current version twice, as `url` and as `version`; the normaliser now uses the url when it is an API download URL, the number otherwise, and `/1` only when the payload says nothing. Register attachments (`motions.ts`) already did this. The version is part of the document cache key, so a revised document is downloaded and extracted again on its next import; no migration needed beyond re-touching.

**Re-touch.** The register backfill still has ~500 Notubiz chunks for 2025–2026 queued; every chunk imported after this deploys picks up current versions. Older documents get their link corrected whenever their meeting is imported again. A dedicated sweep for the historic backlog can follow; the revalidation script's Notubiz signal (400 with an `<error_code>` body) already distinguishes "gone" from "token required".

Test: a fixture document revised to version 3 (url and number) and one with only a version number.