### PR TITLE
Import the meetings under a Notubiz assembly, not only the assembly

### DIFF
--- a/src/coverage/check.ts
+++ b/src/coverage/check.ts
@@ -28,6 +28,7 @@ import {
   normalizeIbabsRegisterDocuments,
 } from "../ibabs/normalize.ts";
 import { NotubizClient } from "../notubiz/client.ts";
+import { expandPublicMeetingIds } from "../notubiz/assemblies.ts";
 import {
   isMotionModule,
   isRegisterModule,
@@ -123,12 +124,11 @@ async function listNotubiz(
     if (events.length === 0) {
       break;
     }
-    for (const event of events) {
-      const record = event as { id?: unknown; permission_group?: unknown };
-      if (record.permission_group === "public" && typeof record.id === "number") {
-        meetingIds.push(record.id);
-      }
-    }
+    meetingIds.push(
+      ...(await expandPublicMeetingIds(events, client, (assemblyId, error) => {
+        listing.warnings.push(`assembly ${assemblyId}: ${errorText(error)}`);
+      })),
+    );
     if (!response.pagination?.has_more_pages) {
       break;
     }

--- a/src/notubiz/assemblies.ts
+++ b/src/notubiz/assemblies.ts
@@ -1,0 +1,62 @@
+/** Which meetings an events page really contains.
+ *
+ * Notubiz lists two kinds of public event. A `meeting` is what it says. An
+ * `assembly` is an evening with several meetings under it -- Castricum's
+ * raadsplein model: one parent event, then carrousels, commissies and the
+ * raadsvergadering as children -- and nearly every substantive document
+ * hangs off an agenda item of a child. The events list carries the assembly
+ * only; its children never appear there, and `events/meetings/{assembly}`
+ * answers with the parent's own agenda and documents (the evening's agenda,
+ * the besluitenlijst). So an import that took the events list at face value
+ * got 88 documents for Castricum's whole 2023 instead of about 2,200 (#255),
+ * and reported success.
+ *
+ * Every public event contributes its own id; an assembly contributes its
+ * children's ids as well, read from `events/assemblies/{id}`. A failing
+ * assembly lookup keeps the parent and reports the children as skipped
+ * through `onAssemblyError`, so the hole is visible instead of silent. */
+export interface AssemblyClient {
+  getAssembly(assemblyId: number): Promise<unknown>;
+}
+
+export async function expandPublicMeetingIds(
+  events: unknown[],
+  client: AssemblyClient,
+  onAssemblyError?: (assemblyId: number, error: unknown) => void | Promise<void>,
+): Promise<number[]> {
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  const add = (id: unknown) => {
+    if (typeof id === "number" && !seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  };
+
+  for (const event of events) {
+    if (!event || typeof event !== "object") {
+      continue;
+    }
+    const record = event as Record<string, unknown>;
+    if (record.permission_group !== "public" || typeof record.id !== "number") {
+      continue;
+    }
+    add(record.id);
+    if (record.type !== "assembly") {
+      continue;
+    }
+    try {
+      const response = (await client.getAssembly(record.id)) as {
+        assembly?: { meetings?: unknown[] };
+      };
+      for (const child of response.assembly?.meetings ?? []) {
+        if (child && typeof child === "object") {
+          add((child as Record<string, unknown>).id);
+        }
+      }
+    } catch (error) {
+      await onAssemblyError?.(record.id, error);
+    }
+  }
+  return ids;
+}

--- a/src/notubiz/client.ts
+++ b/src/notubiz/client.ts
@@ -292,6 +292,13 @@ export class NotubizClient {
     return await fetchJson(buildUrl(`events/meetings/${meetingId}`));
   }
 
+  /** An assembly is an evening with several meetings under it (Castricum's
+   * raadsplein: carrousels, commissies, raad). The events list carries the
+   * assembly, not its meetings; only this endpoint names them. */
+  async getAssembly(assemblyId: number): Promise<unknown> {
+    return await fetchJson(buildUrl(`events/assemblies/${assemblyId}`));
+  }
+
   /** Registries configured for an organisation (Moties, Toezeggingen, …). */
   async listModules(organizationId: number): Promise<NotubizModule[]> {
     const data = await fetchJson<{ modules?: NotubizModule[] }>(

--- a/src/notubiz/extractor.ts
+++ b/src/notubiz/extractor.ts
@@ -1,5 +1,6 @@
 import { materializeDocument } from "../documents/process.ts";
 import { NotubizClient } from "./client.ts";
+import { expandPublicMeetingIds } from "./assemblies.ts";
 import { buildEntityCommitEvent } from "../events/entity_commit.ts";
 import { canonicalMeetingId } from "../ids.ts";
 import { normalizeNotubizDocuments, normalizeNotubizMeeting } from "./normalize.ts";
@@ -214,13 +215,22 @@ export class NotubizMeetingExtractor {
           break;
         }
 
-        const publicMeetingIds = events
-          .filter((item): item is Record<string, unknown> =>
-            Boolean(item && typeof item === "object"),
-          )
-          .filter((eventRecord) => eventRecord.permission_group === "public")
-          .map((eventRecord) => eventRecord.id)
-          .filter((meetingId): meetingId is number => typeof meetingId === "number");
+        // Assemblies (raadsplein evenings) list their child meetings only
+        // through their own endpoint; see assemblies.ts for what was lost
+        // while this took the events list at face value.
+        const publicMeetingIds = await expandPublicMeetingIds(
+          events,
+          this.client,
+          async (assemblyId, error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            await registerIssue({
+              severity: "warning",
+              step: "get_meeting",
+              entity_id: canonicalMeetingId(source, assemblyId),
+              message: `Assembly detail failed; its child meetings are skipped: ${message}`,
+            });
+          },
+        );
 
         const pageMeetings = (
           await mapLimit(publicMeetingIds, meetingConcurrency, async (meetingId) => {

--- a/tests/notubiz_assemblies.test.ts
+++ b/tests/notubiz_assemblies.test.ts
@@ -1,0 +1,145 @@
+import { expandPublicMeetingIds } from "../src/notubiz/assemblies.ts";
+import { NotubizMeetingExtractor } from "../src/notubiz/extractor.ts";
+import { getNotubizSource } from "../src/sources/index.ts";
+import type { NotubizOrganizationAttributes } from "../src/types.ts";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertEquals(actual: unknown, expected: unknown, message: string): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${message}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+Deno.test("an assembly contributes its child meetings, a failing one reports the hole", async () => {
+  // Castricum, March 2023: the events list has assemblies and members-only
+  // meetings; the child meetings are only named by events/assemblies/{id}.
+  const events = [
+    { id: 1000243, type: "meeting", permission_group: "members" },
+    { id: 1000244, type: "assembly", permission_group: "public" },
+    { id: 1000245, type: "assembly", permission_group: "public" },
+    { id: 1000250, type: "meeting", permission_group: "public" },
+    "not an event",
+  ];
+  const failures: number[] = [];
+  const ids = await expandPublicMeetingIds(
+    events,
+    {
+      getAssembly: async (assemblyId: number) => {
+        if (assemblyId === 1000245) {
+          throw new Error("HTTP 500");
+        }
+        return { assembly: { meetings: [{ id: 1085396 }, { id: 1085397 }, { id: 1085396 }] } };
+      },
+    },
+    (assemblyId) => {
+      failures.push(assemblyId);
+    },
+  );
+  assertEquals(
+    ids,
+    [1000244, 1085396, 1085397, 1000245, 1000250],
+    "parents keep their own id, children follow, members-only and duplicates drop",
+  );
+  assertEquals(failures, [1000245], "a failing assembly lookup is reported, its parent kept");
+});
+
+class FakeStorage {
+  private readonly objects = new Map<string, Uint8Array>();
+  async hasObject(key: string): Promise<boolean> {
+    return this.objects.has(key);
+  }
+  async putObject(key: string, body: Uint8Array): Promise<{ url: string }> {
+    this.objects.set(key, body);
+    return { url: `http://storage.test/${key}` };
+  }
+  async getObjectText(key: string): Promise<string> {
+    const bytes = this.objects.get(key);
+    return bytes ? new TextDecoder().decode(bytes) : "";
+  }
+  urlForKey(key: string): string {
+    return `http://storage.test/${key}`;
+  }
+}
+
+function makeMeeting(id: number, documentId: number, parent?: number): Record<string, unknown> {
+  return {
+    id,
+    inactive: false,
+    canceled: false,
+    parent: parent ? { id: parent, self: `api.notubiz.nl/events/${parent}` } : undefined,
+    plannings: [{ start_date: "2023-03-09T20:00:00+01:00", end_date: "2023-03-09T22:30:00+01:00" }],
+    attributes: [
+      { id: "title", value: `Vergadering ${id}` },
+      { id: "location", value: "Raadzaal" },
+    ],
+    documents: [
+      {
+        id: documentId,
+        title: `Document ${documentId}`,
+        self: `api.notubiz.nl/document/${documentId}`,
+        version: 1,
+        last_modified: "2023-02-24 12:24:46",
+        versions: [
+          { file_name: `document-${documentId}.txt`, mime_type: "text/plain", file_size: 12 },
+        ],
+      },
+    ],
+    agenda_items: [],
+  };
+}
+
+Deno.test("the extractor imports the meetings under an assembly, not only the assembly", async () => {
+  const source = getNotubizSource("castricum");
+  const storage = new FakeStorage();
+  const fetchedMeetings: number[] = [];
+  const extractor = new NotubizMeetingExtractor(
+    {
+      getOrganizationAttributes: async (): Promise<NotubizOrganizationAttributes> => ({
+        attributes: { title: "Titel", location: "Locatie" },
+      }),
+      listEvents: async () => ({
+        events: [{ id: 1000244, type: "assembly", permission_group: "public" }],
+        pagination: { has_more_pages: false },
+      }),
+      getAssembly: async () => ({ assembly: { meetings: [{ id: 1085396 }, { id: 1085397 }] } }),
+      getMeeting: async (meetingId: number) => {
+        fetchedMeetings.push(meetingId);
+        return {
+          meeting: makeMeeting(
+            meetingId,
+            12457000 + (meetingId % 1000),
+            meetingId === 1000244 ? undefined : 1000244,
+          ),
+        };
+      },
+      downloadDocument: async () => new TextEncoder().encode("Raadsvoorstel."),
+    } as never,
+    async () => storage as never,
+  );
+
+  const previous = Deno.env.get("WOOZI_MEETING_CONCURRENCY");
+  Deno.env.set("WOOZI_MEETING_CONCURRENCY", "1");
+  try {
+    const extraction = await extractor.extractForDateRange(source, "2023-03-01", "2023-03-31");
+    assertEquals(
+      [...fetchedMeetings].sort(),
+      [1000244, 1085396, 1085397],
+      "the assembly and both children are fetched",
+    );
+    assertEquals(extraction.stats.meeting_count, 3, "three meetings imported");
+    assertEquals(extraction.stats.document_count, 3, "each meeting's document imported");
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("WOOZI_MEETING_CONCURRENCY");
+    } else {
+      Deno.env.set("WOOZI_MEETING_CONCURRENCY", previous);
+    }
+  }
+});


### PR DESCRIPTION
Fixes #255.

Notubiz lists two kinds of public event. A `meeting` is what it says. An `assembly` is an evening with several meetings under it (Castricum's raadsplein: carrousels, commissies, raadsvergadering), and nearly every substantive document hangs off an agenda item of a child meeting. The events list carries the assembly only; its children never appear there, and `events/meetings/{assembly}` answers with the parent's own agenda and besluitenlijst. Taking the events list at face value got Castricum 88 documents for the whole of 2023 instead of about 2,200, and every run reported success.

Verified against the live API for Castricum (organisation 1812), March 2023: 6 events, 4 of them public assemblies; `events/assemblies/1000244` names two child meetings, each public, each with agenda documents that the current import never sees. Bergen (2062) has no assemblies, so the reporter's second suspect is a different case.

- `NotubizClient.getAssembly` reads `events/assemblies/{id}`.
- `expandPublicMeetingIds` (new `src/notubiz/assemblies.ts`) turns an events page into meeting ids: every public event's own id, plus an assembly's children. A failing assembly lookup keeps the parent and reports the skipped children.
- The extractor and the coverage check both use it, so the weekly check counts what the import can reach.

**After deploy:** Castricum needs a full re-run over its whole history to pick up the child meetings (the existing documents are unaffected). I can enqueue that with `scripts/enqueue_full_history.ts --source castricum`.