### PR TITLE
Add gemeente Uitgeest (Notubiz), the fourth BUCH municipality

### DIFF
--- a/src/sources/catalog.data.ts
+++ b/src/sources/catalog.data.ts
@@ -4167,6 +4167,22 @@ export const sourceCatalog = [
     implemented: true,
   },
   {
+    sourceRef: "notubiz:gemeente:uitgeest",
+    key: "uitgeest",
+    label: "Uitgeest",
+    sourceName: "Uitgeest",
+    supplier: "notubiz",
+    organizationType: "gemeente",
+    allmanakId: 26536,
+    cbsId: "GM0450",
+    notubizOrganizationId: 2127,
+    // Not in the ORI inventory: added 2026-09-06 on request (#256), the
+    // fourth BUCH municipality next to Bergen, Castricum and Heiloo.
+    legacyConfigFile: "ori.notubiz.yaml",
+    legacyConfigRoot: "ori.notubiz",
+    implemented: true,
+  },
+  {
     sourceRef: "notubiz:gemeente:veendam",
     key: "veendam",
     label: "Veendam",

--- a/tests/source_catalog.test.ts
+++ b/tests/source_catalog.test.ts
@@ -22,7 +22,8 @@ Deno.test("source catalog includes the full ORI inventory with unique source ref
   const refs = new Set(sources.map((source) => source.sourceRef));
   const keys = new Set(sources.map((source) => source.key));
 
-  assert(sources.length === 330, "expected the full ORI source inventory");
+  // The ORI inventory (329) plus what was added since: Uitgeest (#256).
+  assert(sources.length === 331, "expected the full ORI source inventory plus later additions");
   assert(refs.size === sources.length, "sourceRef must be unique across all imported ORI sources");
   assert(keys.size === sources.length, "key must be globally unique across the source catalog");
   assert(


### PR DESCRIPTION
Fixes #256.

Bergen, Castricum and Heiloo are in the catalog; Uitgeest, which shares one civil service organisation (Werkorganisatie BUCH) with them, was not. Verified against the live APIs: Notubiz organisation 2127 answers as "Gemeente Uitgeest" and lists public meetings for the last months; Almanak systemid 26536 is "Gemeente Uitgeest"; CBS code GM0450.

After deploy the daily scheduler picks the source up; the history needs one `scripts/enqueue_full_history.ts --source uitgeest` run, which I can queue together with Castricum's re-run.