### PR TITLE
Keep the reader off iOS's GPU memory limit: no screen-sized blur there

### DIFF
--- a/web/src/PdfDocumentView.svelte
+++ b/web/src/PdfDocumentView.svelte
@@ -49,6 +49,11 @@
   }
 
   function pageLookahead(centerPage: number): number[] {
+    if (pageCount === 0) {
+      // The first response tells us how long the document is; asking for
+      // pages beyond it before then is a 404 for every page past the end.
+      return [Math.max(1, centerPage)];
+    }
     const bounded = Math.max(1, pageCount > 0 ? Math.min(pageCount, centerPage) : centerPage);
     const start = Math.max(1, bounded - PAGE_FETCH_BEHIND);
     const end = pageCount > 0 ? Math.min(pageCount, bounded + PAGE_FETCH_AHEAD) : bounded + PAGE_FETCH_AHEAD;

--- a/web/styles.css
+++ b/web/styles.css
@@ -3656,3 +3656,26 @@ select {
     background-position: -20% 0;
   }
 }
+
+/* iOS WebKit only (the feature query matches nothing else). Opening a
+   document there killed the tab with WebKit's "Kan deze pagina niet openen"
+   page (#281): a three-page PDF, page images of 816x1056, no script error and
+   no request loop in Chromium -- a renderer that ran out of memory, not a bug
+   in what it was asked to do. The two screen-sized blurred layers are the
+   heaviest thing on that screen: the reader's backdrop blurs the whole
+   results list underneath, and the hero surface blurs behind that again.
+   Large backdrop-filter layers over scrolling content are a known way to push
+   iOS's per-tab GPU memory over its limit. Trade the blur for a slightly
+   denser tint on iOS; the small page-jump pill keeps its blur, it is a few
+   hundred pixels. */
+@supports (-webkit-touch-callout: none) {
+  .detail-overlay__backdrop {
+    backdrop-filter: none;
+    background: rgba(17, 32, 61, 0.6);
+  }
+
+  .hero::after {
+    backdrop-filter: none;
+    background: rgba(246, 248, 251, 0.96);
+  }
+}


### PR DESCRIPTION
Fixes #281.

The screenshot in the issue is WebKit's own crash page: iOS shows "Kan deze pagina niet openen" when a tab's web content process is killed, almost always for memory. What I could rule out from here: the API answers all three page images in under a second at 816×1056 pixels, and in Chromium with a 375-pixel viewport the page opens without a script error or a request loop (five requests, two of them the 404s fixed below). What is left is what iOS is known to choke on: `backdrop-filter` on screen-sized layers over scrolling content. This screen has two of them stacked, the reader's backdrop over the whole results list and the hero surface behind that.

- `styles.css`: under `@supports (-webkit-touch-callout: none)`, which matches iOS WebKit and nothing else, both blurs become a slightly denser plain tint. The small page-jump pill keeps its blur; it is a few hundred pixels.
- `PdfDocumentView.svelte`: the lookahead no longer asks for pages beyond the document before its length is known (opening on page 3 fetched pages 4 and 5 of a three-page document).

**Caveat.** I could not reproduce on real WebKit: the iOS Simulator on this Mac needs `xcode-select` pointed at Xcode first. The blur is the strongest candidate by a distance, and the change is harmless elsewhere, but the reporter's confirmation after deploy is the real test. If it still crashes, the next suspect is the reader sheet's `100vh` box inside the transformed overlay.