### PR TITLE
Render PDF pages at phone resolution when the screen asks for it

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,6 +113,7 @@ added as needed; an existing one is not renamed or removed without a note here.
 | `invalid_offset` | 400 | `offset` is not an integer, or is negative |
 | `unsupported_phrase_slop` | 400 | `query` uses the proximity notation `"a b"~10` |
 | `invalid_page_number` | 400 | the page number in a PDF page URL is not a positive integer |
+| `invalid_scale` | 400 | `scale` on a PDF page URL is not `1` or `2` |
 | `missing_export_source` | 400 | an export call omitted `source` |
 | `unknown_export_source` | 400 | an export call named a source that does not exist |
 | `invalid_export_cursor` | 400 | `cursor` was not produced by an earlier export response |
@@ -520,6 +521,8 @@ source publishes them. See [voting data](#use-case-voting-data) and
 ## PDF page rendering
 
 ### `GET /api/entities/{entity_id}/pdf/page/{page_number}`
+
+Optional `scale=2` renders the page at 192 dpi instead of 96, for screens with two or more device pixels per CSS pixel; any other value is a `400`.
 
 Returns a rendered page of a PDF document as a JPEG image. Pages are rendered at 96 DPI and cached permanently.
 

--- a/scripts/pdf_render_page.sh
+++ b/scripts/pdf_render_page.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: pdf_render_page.sh <page_number>" >&2
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "usage: pdf_render_page.sh <page_number> [dpi]" >&2
   exit 2
 fi
 
@@ -10,6 +10,16 @@ PAGE_NUMBER="$1"
 case "$PAGE_NUMBER" in
   ''|*[!0-9]*)
     echo "invalid page number: $PAGE_NUMBER" >&2
+    exit 2
+    ;;
+esac
+
+# 96 dpi is a laptop screen; a phone shows the same page at two to three
+# device pixels per CSS pixel and turns that into mush when zoomed (#286).
+DPI="${2:-96}"
+case "$DPI" in
+  ''|*[!0-9]*)
+    echo "invalid dpi: $DPI" >&2
     exit 2
     ;;
 esac
@@ -37,4 +47,4 @@ if [ "$PAGE_NUMBER" -lt 1 ] || [ "$PAGE_NUMBER" -gt "$PAGE_COUNT" ]; then
   exit 1
 fi
 
-mutool draw -q -F png -r 96 -o - "$PDF_FILE" "$PAGE_NUMBER" | ffmpeg -loglevel quiet -i pipe:0 -q:v 5 -f mjpeg pipe:1
+mutool draw -q -F png -r "$DPI" -o - "$PDF_FILE" "$PAGE_NUMBER" | ffmpeg -loglevel quiet -i pipe:0 -q:v 5 -f mjpeg pipe:1

--- a/src/documents/thumbnails.ts
+++ b/src/documents/thumbnails.ts
@@ -1,5 +1,29 @@
-export function pdfPageCacheKey(entityId: string, pageNumber: number): string {
-  return `pdf-pages-v4/${entityId}/${pageNumber}.jpg`;
+/** The scales a page can be asked at. 1 is 96 dpi, a laptop screen, and what
+ * the extraction service prewarms for page 1; 2 is 192 dpi for screens with
+ * two or more device pixels per CSS pixel, phones above all. Anything else is
+ * refused rather than rendered, so a URL cannot ask for a poster. */
+export const PDF_PAGE_SCALES = [1, 2] as const;
+export type PdfPageScale = (typeof PDF_PAGE_SCALES)[number];
+export const PDF_PAGE_BASE_DPI = 96;
+
+export function parsePdfPageScale(value: string | null): PdfPageScale | null {
+  if (value === null || value === "") {
+    return 1;
+  }
+  const parsed = Number(value);
+  return (PDF_PAGE_SCALES as readonly number[]).includes(parsed) ? (parsed as PdfPageScale) : null;
+}
+
+/** Scale 1 keeps the key the extraction service prewarms page 1 under; the
+ * others get their own, so a cached 96 dpi page is never served for a 192
+ * dpi request or the other way round. */
+export function pdfPageCacheKey(
+  entityId: string,
+  pageNumber: number,
+  scale: PdfPageScale = 1,
+): string {
+  const suffix = scale === 1 ? "" : `@${scale}x`;
+  return `pdf-pages-v4/${entityId}/${pageNumber}${suffix}.jpg`;
 }
 
 export function pdfPageMetaKey(entityId: string): string {
@@ -11,12 +35,13 @@ const renderScriptPath = new URL("../../scripts/pdf_render_page.sh", import.meta
 export async function renderPdfPageJpeg(
   pdfBytes: Uint8Array,
   pageNumber: number,
+  scale: PdfPageScale = 1,
 ): Promise<{
   imageBytes: Uint8Array;
   pageCount: number | null;
 }> {
   const command = new Deno.Command("sh", {
-    args: [renderScriptPath, String(pageNumber)],
+    args: [renderScriptPath, String(pageNumber), String(PDF_PAGE_BASE_DPI * scale)],
     stdin: "piped",
     stdout: "piped",
     stderr: "piped",

--- a/web/api_errors.ts
+++ b/web/api_errors.ts
@@ -25,6 +25,7 @@ export const API_ERROR_CODES = [
   "invalid_offset",
   "unsupported_phrase_slop",
   "invalid_page_number",
+  "invalid_scale",
   "missing_export_source",
   "unknown_export_source",
   "invalid_export_cursor",

--- a/web/server.ts
+++ b/web/server.ts
@@ -30,7 +30,12 @@ import {
   startStatsRefreshLoop,
 } from "./search_api.ts";
 import { ObjectStorageClient } from "../src/storage/s3.ts";
-import { pdfPageCacheKey, pdfPageMetaKey, renderPdfPageJpeg } from "../src/documents/thumbnails.ts";
+import {
+  parsePdfPageScale,
+  pdfPageCacheKey,
+  pdfPageMetaKey,
+  renderPdfPageJpeg,
+} from "../src/documents/thumbnails.ts";
 import { getStatus } from "./status_api.ts";
 import { RATE_LIMIT_PAGE_UNIT, RateLimiter, type RateVerdict, requestCost } from "./rate_limit.ts";
 import { apiError } from "./api_errors.ts";
@@ -299,9 +304,7 @@ async function handleRequest(request: Request): Promise<Response> {
 
   // The rendered page fetches this; it also stays the plain-text address the
   // route has always had, now with the extension it always was.
-  if (
-    url.pathname === "/docs/migration-guide.md" || url.pathname === "/docs/migration-guide.txt"
-  ) {
+  if (url.pathname === "/docs/migration-guide.md" || url.pathname === "/docs/migration-guide.txt") {
     return await serveMarkdown("./docs/migration-guide.md");
   }
 
@@ -677,7 +680,19 @@ async function handleRequest(request: Request): Promise<Response> {
       );
     }
 
-    const cacheKey = pdfPageCacheKey(entityId, pageNumber);
+    // `scale=2` renders at 192 dpi for screens with two or more device
+    // pixels per CSS pixel; the default is the 96 dpi page a laptop shows
+    // at its natural size (#286).
+    const scale = parsePdfPageScale(url.searchParams.get("scale"));
+    if (scale === null) {
+      return withServerTiming(
+        apiError("invalid_scale", 400, "Ongeldige schaal; kies 1 of 2"),
+        requestStart,
+        metrics,
+      );
+    }
+
+    const cacheKey = pdfPageCacheKey(entityId, pageNumber, scale);
     const cached = await measureTiming(metrics, "cache", () => storage.getObjectBytes(cacheKey));
     if (cached) {
       const headers = new Headers({
@@ -723,7 +738,7 @@ async function handleRequest(request: Request): Promise<Response> {
       let renderedPage: Awaited<ReturnType<typeof renderPdfPageJpeg>>;
       try {
         renderedPage = await measureTiming(metrics, "render", () =>
-          renderPdfPageJpeg(pdfBytes, pageNumber),
+          renderPdfPageJpeg(pdfBytes, pageNumber, scale),
         );
       } catch (error) {
         const notFound = error instanceof Error && error.message === "PDF page not found";

--- a/web/src/PdfDocumentView.svelte
+++ b/web/src/PdfDocumentView.svelte
@@ -16,7 +16,13 @@
 
   const PAGE_FETCH_BEHIND = 1;
   const PAGE_FETCH_AHEAD = 2;
-  const PAGE_CACHE_BUFFER = 24;
+  // Pages kept decoded on either side of the one being read. A 192 dpi page
+  // decodes to about 14 MB; two dozen of those on each side is what gets a
+  // phone's tab killed, and a reader rarely jumps more than a few pages.
+  const PAGE_CACHE_BUFFER = 6;
+  // A phone shows the page at two or three device pixels per CSS pixel; the
+  // 96 dpi rendering that suits a laptop is mush there once zoomed (#286).
+  const PAGE_SCALE = typeof window !== "undefined" && window.devicePixelRatio >= 1.5 ? 2 : 1;
   const DEFAULT_PAGE_ASPECT_RATIO = 1 / 1.414;
 
   let containerEl: HTMLDivElement | null = null;
@@ -40,7 +46,7 @@
   }
 
   function pageImageUrl(pageNumber: number): string {
-    return `${url}/page/${pageNumber}`;
+    return PAGE_SCALE === 1 ? `${url}/page/${pageNumber}` : `${url}/page/${pageNumber}?scale=${PAGE_SCALE}`;
   }
 
   function applyDocumentPageAspectRatio(ratio: number): void {


### PR DESCRIPTION
Fixes #286.

The reader's page images are rendered at 96 dpi: a laptop screen at its natural size. A phone shows the same 816×1056 image at two or three device pixels per CSS pixel, and the reporter's screenshot is exactly that: readable layout, unreadable letters once zoomed.

- `scripts/pdf_render_page.sh` takes the dpi as a second argument.
- `GET /api/entities/{id}/pdf/page/{n}?scale=2` renders at 192 dpi under its own cache key (`{n}@2x.jpg`), so the 96 dpi page 1 the extraction service prewarms is never served for a 2× request. Any other scale is a `400` (`invalid_scale`, documented).
- The viewer asks for 2× when `devicePixelRatio >= 1.5`, and keeps six decoded pages on each side of the current one instead of twenty-four: a 192 dpi page decodes to about 14 MB, and that buffer is what pushed an iPhone tab over its memory limit in #281.

Pinch-zoom on the sheet remains the browser's own zoom, which is awkward inside a fixed overlay; a proper zoom control in the reader is a separate piece of work.

Verified: type check, web build, shell syntax. Rendering itself needs `mutool`, which is only in the image; CI's web job builds the bundle.