### PR TITLE
Keep the home page inside a phone's screen

### DIFF
--- a/tests/api_errors.test.ts
+++ b/tests/api_errors.test.ts
@@ -30,6 +30,7 @@ Deno.test("the published set of error codes is stable", () => {
       "invalid_limit",
       "invalid_offset",
       "invalid_page_number",
+      "invalid_scale",
       "missing_export_source",
       "pdf_fetch_failed",
       "pdf_not_found",

--- a/web/styles.css
+++ b/web/styles.css
@@ -69,7 +69,13 @@ select {
 
 .hero {
   position: relative;
-  overflow: visible;
+  /* The decorative glows reach past the right edge of a phone screen, and
+     WebKit widens the layout to include them (#290). Clip sideways only:
+     `clip` makes no scroll container, so the sticky search bar and the
+     organisation picker's dropdown keep working, and nothing vertical is
+     cut. */
+  overflow-x: clip;
+  overflow-y: visible;
   padding: 2rem 1.5rem 0;
   min-height: min(82vh, 56rem);
   transition:
@@ -301,7 +307,13 @@ select {
 .brand {
   margin: 0;
   text-align: center;
-  font-size: clamp(2.6rem, 5vw, 4.6rem);
+  /* The floor of 2.6rem set "OpenBesluitvorming" at 41.6px, which is 422px
+     of one unbreakable word on a 375px phone. WebKit does not clip that: it
+     widens the whole layout to fit, so every centred thing sat off-centre and
+     the right edge of the page fell off the screen (#290). Below about 470px
+     the size follows the viewport instead, 8.8vw, which keeps the word inside
+     the padding down to 320px. */
+  font-size: min(clamp(2.6rem, 5vw, 4.6rem), 8.8vw);
   line-height: 0.95;
   font-weight: 800;
   letter-spacing: -0.04em;


### PR DESCRIPTION
Fixes #290.

On iOS the home page was laid out 471 px wide on a 375 px screen: the title ran off the right edge, the search box past it, the intro text cut, and everything "centred" sat off-centre. Measured in a 375 px viewport: two things were wider than the viewport, and WebKit widens the whole layout to fit them where Chromium merely clips.

1. The brand's font-size floor (`clamp(2.6rem, …)`) made the one unbreakable word "OpenBesluitvorming" 422 px wide. Below about 470 px it now follows the viewport (`8.8vw`), which keeps it inside the padding down to 320 px; above that nothing changes.
2. The hero's decorative glows reach 96 px past the right edge. The hero now has `overflow-x: clip` with `overflow-y: visible`: `clip` creates no scroll container, so the sticky search bar and the organisation picker's dropdown keep working and nothing vertical is cut.

Verified by injecting both rules into the live page in a 375 px viewport: layout width 471 → 375, zero elements past the right edge.