### PR TITLE
Render a supplier's plain agenda text as markdown, so its links are links

### DIFF
--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,0 +1,32 @@
+import { renderSupplierText } from "../web/src/markdown.ts";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+Deno.test("plain supplier text with markdown links becomes clickable, and safe", () => {
+  // #295: Harderwijk's agenda text, as iBabs delivers it.
+  const html = renderSupplierText(
+    "De vergadering is te volgen via [www.harderwijk.nl/vergaderingen](https://www.harderwijk.nl/vergaderingen).&#xD;\n&#xD;\nProces: <script>alert(1)</script> is geen markup.",
+  );
+  assert(
+    html.includes(
+      '<a href="https://www.harderwijk.nl/vergaderingen">www.harderwijk.nl/vergaderingen</a>',
+    ),
+    `the markdown link is rendered, got ${html}`,
+  );
+  assert(!html.includes("&#xD;") && !html.includes("\r"), "carriage-return entities are dropped");
+  assert(!html.includes("<script>"), "angle brackets in supplier text never become tags");
+  assert(html.includes("&lt;script&gt;"), "they are shown as text instead");
+});
+
+Deno.test("supplier HTML is passed through as before", () => {
+  const html = "<p>Vergadering in de <b>raadzaal</b>.</p>";
+  assert(renderSupplierText(html) === html, "HTML from Notubiz keeps its markup");
+  assert(
+    renderSupplierText("") === "" && renderSupplierText(undefined) === "",
+    "empty stays empty",
+  );
+});

--- a/web/src/MeetingAgendaTree.svelte
+++ b/web/src/MeetingAgendaTree.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { renderDocumentMarkdown } from "./markdown.ts";
+  import { renderDocumentMarkdown, renderSupplierText } from "./markdown.ts";
   import { createEventDispatcher } from "svelte";
   import type { EntityContentResponse, MeetingAgendaItem, MeetingMotion } from "../../src/types.ts";
   import ReaderLoading from "./ReaderLoading.svelte";
@@ -129,7 +129,7 @@
           </header>
 
           {#if item.description}
-            <div class="meeting-agenda__description">{@html item.description}</div>
+            <div class="meeting-agenda__description">{@html renderSupplierText(item.description)}</div>
           {/if}
 
           {#if item.documents?.length}

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -28,3 +28,39 @@ export function renderDocumentMarkdown(markdown?: string): string {
 export function renderOwnMarkdown(markdown: string): string {
   return parse(markdown);
 }
+
+/* The tags a supplier's HTML actually uses. Anything else in angle brackets
+ * is text and gets escaped: a stray `<script>` in plain text is not markup. */
+const HTML_TAG =
+  /<\/?(?:p|br|a|ul|ol|li|strong|b|em|i|u|div|span|h[1-6]|table|thead|tbody|tr|td|th|blockquote|hr)\b[^>]*>/i;
+
+/** Decode the numeric character references a supplier leaves in plain text
+ * (`&#xD;` for a carriage return is iBabs's favourite) so they neither show
+ * up literally after escaping nor survive as stray `\r`. */
+function decodeNumericEntities(text: string): string {
+  return text
+    .replaceAll(/&#x([0-9a-f]+);/gi, (_match, hex: string) =>
+      String.fromCodePoint(parseInt(hex, 16)),
+    )
+    .replaceAll(/&#(\d+);/g, (_match, dec: string) => String.fromCodePoint(parseInt(dec, 10)))
+    .replaceAll("\r", "");
+}
+
+/** Text a supplier wrote about a meeting or an agenda item, inserted with
+ * {@html}.
+ *
+ * Notubiz hands over HTML and that is shown as it is, as before. iBabs hands
+ * over plain text that griffies write with markdown in it: a link such as
+ * `[www.harderwijk.nl/vergaderingen](https://www.harderwijk.nl/vergaderingen)`
+ * used to appear with its brackets, unclickable (#295). Text without markup
+ * is now escaped and rendered as markdown, so links become links and line
+ * breaks survive, while nothing in it can become markup of its own. */
+export function renderSupplierText(text?: string): string {
+  if (!text?.trim()) {
+    return "";
+  }
+  if (HTML_TAG.test(text)) {
+    return text;
+  }
+  return parse(escapeMarkdownSource(decodeNumericEntities(text)));
+}


### PR DESCRIPTION
Fixes #295.

Meeting and agenda descriptions are inserted with `{@html}`. That suits Notubiz, which hands over HTML, but iBabs hands over plain text that griffies write with markdown in it: Harderwijk's `[www.harderwijk.nl/vergaderingen](https://www.harderwijk.nl/vergaderingen)` showed with its brackets, unclickable, with `&#xD;` carriage-return entities between the paragraphs.

`renderSupplierText` now decides per text: if it contains the tags a supplier's HTML actually uses (`p`, `br`, `a`, lists, headings, tables...) it is passed through as before; otherwise numeric entities are decoded, the text is escaped and rendered as markdown with line breaks kept. So links become links, and a stray `<script>` in plain text is shown as text rather than executed, which the old passthrough would not have guaranteed.

Two tests: the Harderwijk text (link rendered, entities gone, angle brackets escaped) and HTML passthrough.