### PR TITLE
Let a purge survive a store that fails a few deletes per pass

### DIFF
--- a/scripts/purge_source.ts
+++ b/scripts/purge_source.ts
@@ -28,7 +28,7 @@
 //      a delete-by-query when you cannot wait for that.
 import { getExportLog } from "../src/exports/log.ts";
 import { QuickwitClient } from "../src/quickwit/client.ts";
-import { getSource } from "../src/sources/index.ts";
+import { getProjectableSource } from "../src/sources/index.ts";
 import { ObjectStorageClient } from "../src/storage/s3.ts";
 import { sourceStoragePrefixes } from "../src/storage/prefixes.ts";
 import type { ExportChangeRecord } from "../src/types.ts";
@@ -71,8 +71,10 @@ async function main(): Promise<void> {
   }
 
   // Resolves through the catalog, so a typo fails here rather than silently
-  // purging nothing.
-  const source = getSource(sourceKey);
+  // purging nothing. Through the projectable lookup, not the runnable one: a
+  // source is switched off in the catalog before its data is removed, and
+  // the runnable lookup refused exactly those (2026-09-10).
+  const source = getProjectableSource(sourceKey);
   const apply = hasFlag("apply");
   const purgeQuickwit = hasFlag("quickwit");
   const keepStorage = hasFlag("keep-storage");

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -20,6 +20,14 @@ const READ_TIMEOUT_MS = Number(Deno.env.get("WOOZI_S3_READ_TIMEOUT_MS") ?? "1500
  * second apart are three chances to hit the same throttle. A throttle wants
  * patience, not persistence. `Retry-After`, when the server sends one, wins. */
 const READ_ATTEMPTS = 6;
+const DELETE_ATTEMPTS = 4;
+
+/** Shorter than a read's back-off: a purge makes tens of thousands of these,
+ * and a store that answers a few of them with a 5xx usually takes the retry
+ * a moment later. */
+function deleteRetryDelayMs(attempt: number): number {
+  return Math.min(300 * 2 ** (attempt - 1), 2_400);
+}
 const READ_RETRY_BASE_MS = 1_000;
 const READ_RETRY_MAX_MS = 16_000;
 
@@ -340,41 +348,94 @@ export class ObjectStorageClient {
     };
   }
 
+  /** Delete one object, with the same ceiling and retries as a read: the
+   * store answers a few percent of requests slowly or with a 5xx, and one
+   * of those must not stand for the whole batch. 404 is success here. */
+  private async deleteObject(key: string): Promise<void> {
+    const url = this.objectUrl(key);
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= DELETE_ATTEMPTS; attempt += 1) {
+      let response: Response;
+      try {
+        const signed = await this.client.sign(url, { method: "DELETE" });
+        response = await fetch(signed, { signal: AbortSignal.timeout(READ_TIMEOUT_MS) });
+      } catch (error) {
+        lastError = error;
+        await sleep(deleteRetryDelayMs(attempt));
+        continue;
+      }
+      await response.body?.cancel();
+      if (response.ok || response.status === 404) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+      if (response.status < 500 && response.status !== 429) {
+        break;
+      }
+      await sleep(deleteRetryDelayMs(attempt));
+    }
+    throw describeStorageError("delete", key, lastError);
+  }
+
+  /** Delete these objects, all of them tried. Per-key DELETE instead of the
+   * Multi-Object Delete API: the batch API requires a Content-MD5 header,
+   * which WebCrypto cannot produce.
+   *
+   * A key that still fails after its retries does not stop the others: the
+   * purge of a whole source lists tens of thousands of keys, and aborting
+   * the pass at the first bad one meant starting over from the beginning
+   * every time, which a store that fails a fraction of a percent of
+   * requests never lets finish (2026-09-10, Goeree-Overflakkee). The
+   * failures are reported together at the end, and the caller re-lists the
+   * prefix to pick them up. */
   async deleteObjects(keys: string[]): Promise<void> {
-    // Per-key DELETE instead of the Multi-Object Delete API: our delete
-    // volumes are tiny (takedowns, test cleanup) and the batch API requires
-    // a Content-MD5 header, which WebCrypto cannot produce.
+    const failures: Error[] = [];
     for (const key of keys) {
       try {
-        const response = await this.client.fetch(this.objectUrl(key), { method: "DELETE" });
-        await response.body?.cancel();
-        if (!response.ok && response.status !== 404) {
-          throw new Error(`HTTP ${response.status}`);
-        }
+        await this.deleteObject(key);
       } catch (error) {
-        throw describeStorageError("delete", key, error);
+        failures.push(error instanceof Error ? error : new Error(String(error)));
       }
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        `${failures.length} of ${keys.length} objects could not be deleted; first: ${failures[0].message}`,
+      );
     }
   }
 
-  /** Deletes every object under the prefix. Returns the deleted keys. */
+  /** Deletes every object under the prefix. Returns the deleted keys.
+   *
+   * One pass over the listing; a page whose deletes partly failed does not
+   * stop the pass, the leftovers are reported at the end and are still
+   * there for the next pass to find. */
   async deleteByPrefix(prefix: string): Promise<string[]> {
     if (!prefix || prefix === "/") {
       throw new Error(`Refusing to delete by empty prefix`);
     }
     const deleted: string[] = [];
+    const leftovers: string[] = [];
     let startAfter: string | undefined;
     while (true) {
       const { keys, isTruncated } = await this.listObjects({ prefix, startAfter });
       if (keys.length === 0) {
         break;
       }
-      await this.deleteObjects(keys);
-      deleted.push(...keys);
+      try {
+        await this.deleteObjects(keys);
+        deleted.push(...keys);
+      } catch (error) {
+        leftovers.push(error instanceof Error ? error.message : String(error));
+      }
       if (!isTruncated) {
         break;
       }
       startAfter = keys[keys.length - 1];
+    }
+    if (leftovers.length > 0) {
+      throw new Error(
+        `prefix ${prefix}: ${leftovers.length} page(s) kept objects after one pass (${leftovers[0]})`,
+      );
     }
     return deleted;
   }

--- a/tests/s3_delete_resilience.test.ts
+++ b/tests/s3_delete_resilience.test.ts
@@ -1,0 +1,76 @@
+import { assert, assertRejects } from "jsr:@std/assert";
+
+// The timeout is read once at module load, so set it before importing.
+Deno.env.set("WOOZI_S3_READ_TIMEOUT_MS", "80");
+Deno.env.set("S3_STORAGE_BUCKET_NAME", "test-bucket");
+Deno.env.set("S3_STORAGE_ENDPOINT", "https://storage.test");
+Deno.env.set("S3_STORAGE_REGION", "test-1");
+Deno.env.set("S3_ACCESS_KEY", "key");
+Deno.env.set("S3_SECRET_KEY", "secret");
+const { ObjectStorageClient } = await import("../src/storage/s3.ts");
+
+type FetchFn = typeof globalThis.fetch;
+
+async function withFetch<T>(stub: FetchFn, run: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = stub;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+function keyOf(input: RequestInfo | URL): string {
+  const url = new URL(input instanceof Request ? input.url : String(input));
+  return decodeURIComponent(url.pathname.split("/").slice(2).join("/"));
+}
+
+Deno.test("one object that keeps failing does not stop the others from being deleted", async () => {
+  // 2026-09-10: purging Goeree-Overflakkee listed tens of thousands of keys
+  // and the store failed a handful of deletes per pass; aborting at the first
+  // one restarted the pass from the beginning, forever.
+  const deleted: string[] = [];
+  const stub: FetchFn = async (input, init) => {
+    const method = input instanceof Request ? input.method : init?.method;
+    if (method !== "DELETE") {
+      throw new Error(`only DELETE expected, got ${method}`);
+    }
+    const key = keyOf(input);
+    if (key === "documents/bad") {
+      return new Response("", { status: 503 });
+    }
+    deleted.push(key);
+    return new Response(null, { status: 204 });
+  };
+  const client = await ObjectStorageClient.fromEnvironment();
+  await withFetch(stub, async () => {
+    const error = await assertRejects(
+      () => client.deleteObjects(["documents/a", "documents/bad", "documents/b"]),
+      Error,
+    );
+    assert(
+      error.message.includes("1 of 3"),
+      `the failure is reported at the end, got ${error.message}`,
+    );
+  });
+  assert(
+    deleted.includes("documents/a") && deleted.includes("documents/b"),
+    "the other two were deleted",
+  );
+});
+
+Deno.test("a delete that fails once is retried, and a 404 counts as done", async () => {
+  let attempts = 0;
+  const stub: FetchFn = async (input) => {
+    const key = keyOf(input);
+    if (key === "documents/flaky") {
+      attempts += 1;
+      return new Response(attempts === 1 ? "" : null, { status: attempts === 1 ? 500 : 204 });
+    }
+    return new Response("", { status: 404 });
+  };
+  const client = await ObjectStorageClient.fromEnvironment();
+  await withFetch(stub, () => client.deleteObjects(["documents/flaky", "documents/gone"]));
+  assert(attempts === 2, `retried once, got ${attempts} attempts`);
+});


### PR DESCRIPTION
Found while purging the unapproved sources of #277.

Purging Goeree-Overflakkee lists tens of thousands of objects; Hetzner's store answers a handful of deletes per pass with a 5xx. One such failure threw out of `deleteObjects`, `deleteByPrefix` aborted the pass, and `purge_source.ts` retried the whole prefix from the beginning, five times, each time hitting another transient failure somewhere in the list: three hours on one source, nothing finished.

- `deleteObject` (new, private): the read path's timeout, four attempts with a short back-off, 404 counts as done, other 4xx not retried.
- `deleteObjects`: every key is tried; failures are reported together at the end instead of stopping the batch.
- `deleteByPrefix`: a page whose deletes partly failed does not stop the pass; leftovers are reported at the end and are still listed for the next pass, which the purge script's own retry provides.
- `purge_source.ts` resolves through `getProjectableSource`, so a source switched off in the catalog (the step before removing its data) can be purged with the live image; the runnable lookup refused exactly those today.

Tests: a key that keeps failing does not block the others; a key that fails once is retried, and a 404 is success.