### PR TITLE
Give every organization on the status endpoint its exact indexed document count

### DIFF
--- a/API.md
+++ b/API.md
@@ -406,6 +406,7 @@ at all — i.e. how long the outage has lasted.
 | `lastErrorMessage` | Why the last run failed. Present only when it did. Query strings are stripped |
 | `latestContentDate` | Newest meeting date held for this organization. Often in the future — an agenda is published before the meeting happens |
 | `lastIndexedAt` | When anything was last written to the search index for this organization |
+| `indexedDocuments` | Documents in the search index for this organization, exact at the moment of the request: one per document, pages not counted. The number to reconcile against the source system's own list. Absent when the index did not answer |
 | `coverage` | Present once the weekly coverage check has covered this organization. What the source system's own API listed for a date window, against what the index holds: `supplierDocuments`, `heldDocuments`, `missingDocuments` (the first two partition the third), `ratio` (held over supplier; 1 means complete), `windowFrom`/`windowTo`, `checkedAt`, `missingSample` (a few missing document ids), `lowerBound` (true when some supplier requests failed, so the gap may be larger), and `error` when the check itself failed. `state: "ok"` says the last import ran; `coverage` says whether it asked for everything |
 | `discontinuedAt` | The date the organization ceased to exist. Only on `discontinued` |
 | `succeededBy` | `{ cbsId, label, sourceKey }` of the organization that took over. `sourceKey` is absent when we do not import the successor. Only on `discontinued` |

--- a/src/types.ts
+++ b/src/types.ts
@@ -900,6 +900,10 @@ export interface SourceStatus {
   latestContentDate?: string;
   /** When anything was last written to the search index for this source. */
   lastIndexedAt?: string;
+  /** Documents in the search index for this source, exact at the moment of
+   * the request: one per document, pages not counted. Absent when the index
+   * did not answer. */
+  indexedDocuments?: number;
   /** Set only when `state` is `discontinued`: when the organization ceased to
    * exist, and who took over. `sourceKey` is present when we import the
    * successor, so a caller can follow the trail. */

--- a/tests/status_api.test.ts
+++ b/tests/status_api.test.ts
@@ -225,6 +225,7 @@ Deno.test("index activity is merged per source and is optional", () => {
         {
           latestContentDate: "2026-08-20T13:30:00.000Z",
           lastIndexedAt: "2026-08-16T00:09:59.000Z",
+          documentCount: 12345,
         },
       ],
     ]),
@@ -235,6 +236,11 @@ Deno.test("index activity is merged per source and is optional", () => {
     "a meeting already on the agenda for next week",
   );
   assertEquals(withActivity.indexActivityAvailable, true, "the index answered");
+  assertEquals(
+    source(withActivity, "soest").indexedDocuments,
+    12345,
+    "the exact document count travels with the activity (#260)",
+  );
 
   const withoutActivity = build({ indexActivity: null });
   assertEquals(

--- a/web/search_api.ts
+++ b/web/search_api.ts
@@ -1353,6 +1353,10 @@ export interface SourceIndexActivity {
   latestContentDate?: string;
   /** Newest `time`: when we last wrote anything at all for the source. */
   lastIndexedAt?: string;
+  /** Documents in the index for the source, exact at the moment of asking:
+   * one row per document, pages not counted. What a reconciliation against
+   * the source's own list or the legacy index compares with (#260). */
+  documentCount?: number;
 }
 
 /** Quickwit reports datetime metric aggregations as nanoseconds since the
@@ -1418,6 +1422,28 @@ export async function getSourceIndexActivity(): Promise<Map<string, SourceIndexA
     latest_start_date?: { value?: unknown };
   }>;
 
+  // A second request for the document count per source: Quickwit's
+  // aggregations cannot filter inside a bucket, and the first request counts
+  // every row (meetings, pages, motions). One row per Document is the number
+  // people reconcile with.
+  const documentCounts = new Map<string, number>();
+  try {
+    const counted = await quickwit.searchRequest({
+      query: `projection_version:${escapeTerm(currentProjectionVersion())} AND entity_type:Document`,
+      max_hits: 0,
+      aggs: { by_source: { terms: { field: "source_key", size: 500 } } },
+    });
+    const countBuckets = ((counted.aggregations?.by_source as { buckets?: unknown[] })?.buckets ??
+      []) as Array<{ key?: unknown; doc_count?: unknown }>;
+    for (const bucket of countBuckets) {
+      if (typeof bucket.key === "string" && typeof bucket.doc_count === "number") {
+        documentCounts.set(bucket.key, bucket.doc_count);
+      }
+    }
+  } catch {
+    // The activity half still answers; a missing count is absent, not zero.
+  }
+
   const activity = new Map<string, SourceIndexActivity>();
   for (const bucket of buckets) {
     const sourceKey = String(bucket.key ?? "");
@@ -1425,6 +1451,7 @@ export async function getSourceIndexActivity(): Promise<Map<string, SourceIndexA
     activity.set(sourceKey, {
       lastIndexedAt: fromAggregationTimestamp(bucket.last_indexed?.value),
       latestContentDate: fromAggregationTimestamp(bucket.latest_start_date?.value),
+      documentCount: documentCounts.get(sourceKey),
     });
   }
   return activity;

--- a/web/status_api.ts
+++ b/web/status_api.ts
@@ -134,6 +134,7 @@ export function buildStatusResponse(options: {
         lastErrorMessage,
         latestContentDate: activity?.latestContentDate,
         lastIndexedAt: activity?.lastIndexedAt,
+        indexedDocuments: activity?.documentCount,
         discontinuedAt: source.discontinuedAt,
         succeededBy:
           source.succeededByCbsId && source.succeededByLabel


### PR DESCRIPTION
Addresses the remaining part of #260.

`/api/status` now carries `indexedDocuments` per organization: the number of Document rows in the search index for that source, exact at the moment of the request (pages, meetings and motions not counted). Together with `coverage` (what the source lists against what we hold, weekly) and `lastIndexedAt` this is the number to reconcile against a griffie's own list or the legacy index.

Implementation: a second aggregation request in `getSourceIndexActivity`, restricted to `entity_type:Document`, because Quickwit's aggregations cannot filter inside a bucket. If that request fails the field is absent rather than zero; the rest of the status answer is unaffected. Documented in API.md, test extended.